### PR TITLE
feat(#21): Land Parcel CRUD — schema, actions, list, form, view modal…

### DIFF
--- a/docs/rule&progress.md
+++ b/docs/rule&progress.md
@@ -12,8 +12,9 @@
 | **Proyek** | Smallholder HUB — Management Information System |
 | **Stack** | Next.js 16 · React 19 · Tailwind 4 · Shadcn UI · Prisma 7 · MapLibre |
 | **Repository** | `WRI-Indonesia/mis-smallholder-hub` |
-| **Terakhir Diupdate** | 2026-05-04 |
+| **Terakhir Diupdate** | 2026-05-05 |
 | **Diupdate Oleh** | Sofyan (via AI-assisted development) |
+| **Branch Aktif** | `dev-phase-4` |
 
 ---
 
@@ -88,7 +89,7 @@ Fase 1 ✅ → Fase 2 ✅ → Fase 4 (Master Data) → Fase 3 (Auth) → Fase 5�
 | **1** | Initialization & UI Statis | ✅ Selesai | — | — |
 | **2** | Database Schema & Migrations | ✅ Selesai | — | — |
 | **3** | Autentikasi & RBAC | ⏭️ Skipped | — | — |
-| **4** | Master Data CRUD | 🚧 In Progress | [#17](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/17) Shared Infra ✅ · [#18](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/18) Regions ✅ · [#19](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/19) Groups ✅ · [#20](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/20) Farmers · [#21](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/21) Parcels · [#22](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/22) Final QA | [Milestone #3](https://github.com/WRI-Indonesia/mis-smallholder-hub/milestone/3) |
+| **4** | Master Data CRUD | 🚧 In Progress | [#17](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/17) Shared Infra ✅ · [#18](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/18) Regions ✅ · [#19](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/19) Groups ✅ · [#20](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/20) Farmers · [#21](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/21) Parcels ✅ · [#22](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/22) Final QA | [Milestone #3](https://github.com/WRI-Indonesia/mis-smallholder-hub/milestone/3) |
 | **5** | CMS & Content Management | 🔲 | — | — |
 | **6** | Tools (Import/Export/GIS) | 🔲 | — | — |
 | **7** | Dashboard & Reporting (DB) | 🔲 | — | — |
@@ -102,6 +103,7 @@ Fase 1 ✅ → Fase 2 ✅ → Fase 4 (Master Data) → Fase 3 (Auth) → Fase 5�
 
 | Tanggal | Perubahan |
 |---------|-----------|
+| 2026-05-05 | Issue #21 selesai — Parcels CRUD lengkap: Zod schema, server actions (PostGIS raw SQL), page, list client (filter kelompok tani, search, pagination), form modal (petani searchable), view modal (detail + peta MapLibre dengan switcher Light/Dark/Satellite), 16 unit tests. |
 | 2026-05-04 | Restrukturisasi dokumen. Tambah rules. Skip Fase 3, mulai Fase 4. GitHub Issues & Milestone dibuat. |
 | 2026-04-14 | Fase 2 selesai — Prisma 7 modular schema, 3 migrasi PostgreSQL + PostGIS, seeding modular. |
 | 2026-04-13 | Fase 1.8 selesai — Refaktor arsitektur (server component, decomposition, naming, barrel). |

--- a/src/app/(admin)/admin/master-data/parcels/page.tsx
+++ b/src/app/(admin)/admin/master-data/parcels/page.tsx
@@ -1,2 +1,52 @@
-import PlaceholderPage from "@/components/layout/placeholder-page"
-export default function Page() { return <PlaceholderPage title="Dalam Pengembangan" /> }
+import { getLandParcels, getFarmersForDropdown, getFarmerGroupsForDropdown, getCommodities } from "@/server/actions/land-parcel";
+import { ParcelListClient } from "./parcel-list-client";
+import { Card, CardContent } from "@/components/ui/card";
+
+export const metadata = { title: "Data Persil Lahan" };
+
+export default async function MasterDataParcelsPage(props: {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const searchParams = await props.searchParams;
+  const page = Number(searchParams?.page) || 1;
+  const search =
+    typeof searchParams?.search === "string" ? searchParams.search : undefined;
+  const farmerGroupId =
+    typeof searchParams?.group === "string" ? searchParams.group : undefined;
+
+  const [parcelsResult, farmersResult, groupsResult, commoditiesResult] = await Promise.all([
+    getLandParcels(page, 10, search, farmerGroupId),
+    getFarmersForDropdown(),
+    getFarmerGroupsForDropdown(),
+    getCommodities(),
+  ]);
+
+  return (
+    <div className="p-6 space-y-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Persil Lahan</h1>
+        <p className="text-muted-foreground mt-1">
+          Manajemen data persil lahan petani. Geometry (polygon) akan dikelola
+          melalui GIS Tools pada Fase 6.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          <ParcelListClient
+            initialData={
+              parcelsResult.success && parcelsResult.data
+                ? parcelsResult.data
+                : { data: [], total: 0, page: 1, totalPages: 1 }
+            }
+            farmers={farmersResult.success ? (farmersResult.data ?? []) : []}
+            groups={groupsResult.success ? (groupsResult.data ?? []) : []}
+            commodities={
+              commoditiesResult.success ? (commoditiesResult.data ?? []) : []
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/master-data/parcels/parcel-form-modal.tsx
+++ b/src/app/(admin)/admin/master-data/parcels/parcel-form-modal.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { landParcelSchema, LandParcelFormValues } from "@/validations/land-parcel.schema";
+import {
+  createLandParcel,
+  updateLandParcel,
+  type LandParcelRow,
+  type FarmerDropdownItem,
+  type CommodityDropdownItem,
+} from "@/server/actions/land-parcel";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface ParcelFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  parcel?: LandParcelRow | null;
+  farmers: FarmerDropdownItem[];
+  commodities: CommodityDropdownItem[];
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ParcelFormModal({
+  isOpen,
+  onClose,
+  parcel,
+  farmers,
+  commodities,
+}: ParcelFormModalProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [openFarmer, setOpenFarmer] = useState(false);
+  const isEditing = !!parcel;
+
+  const form = useForm<LandParcelFormValues>({
+    resolver: zodResolver(landParcelSchema as any),
+    defaultValues: {
+      farmerId: parcel?.farmerId ?? "",
+      commodityCode: parcel?.commodityCode ?? "",
+      parcelCode: parcel?.parcelCode ?? "",
+      polygonSizeHa: parcel?.polygonSizeHa ?? null,
+      legalId: parcel?.legalId ?? "",
+      legalSizeHa: parcel?.legalSizeHa ?? null,
+      status: parcel?.status ?? "",
+    },
+  });
+
+  async function onSubmit(data: LandParcelFormValues) {
+    setIsPending(true);
+    const result = isEditing
+      ? await updateLandParcel(parcel!.id, data)
+      : await createLandParcel(data);
+    setIsPending(false);
+
+    if (result.success) {
+      toast.success(
+        isEditing
+          ? "Data persil lahan diperbarui."
+          : "Persil lahan berhasil dibuat."
+      );
+      onClose();
+    } else {
+      toast.error(result.error);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? "Edit Persil Lahan" : "Tambah Persil Lahan Baru"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 pt-4">
+
+            {/* Petani — searchable combobox */}
+            <FormField
+              control={form.control}
+              name="farmerId"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Petani *</FormLabel>
+                  <Popover open={openFarmer} onOpenChange={setOpenFarmer}>
+                    <PopoverTrigger
+                      render={
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={openFarmer}
+                          className={cn(
+                            "w-full justify-between",
+                            !field.value && "text-muted-foreground"
+                          )}
+                        />
+                      }
+                    >
+                      {field.value
+                        ? (() => {
+                            const f = farmers.find((f) => f.id === field.value);
+                            return f
+                              ? `${f.name} — ${f.farmerGroup.name}`
+                              : "Pilih Petani";
+                          })()
+                        : "Pilih Petani"}
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </PopoverTrigger>
+                    <PopoverContent className="w-full p-0" align="start">
+                      <Command>
+                        <CommandInput placeholder="Cari nama atau NIK..." />
+                        <CommandList>
+                          <CommandEmpty>Petani tidak ditemukan.</CommandEmpty>
+                          <CommandGroup>
+                            {farmers.map((f) => (
+                              <CommandItem
+                                key={f.id}
+                                value={`${f.name} ${f.nik}`}
+                                onSelect={() => {
+                                  form.setValue("farmerId", f.id);
+                                  setOpenFarmer(false);
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    f.id === field.value
+                                      ? "opacity-100"
+                                      : "opacity-0"
+                                  )}
+                                />
+                                <span className="font-medium">{f.name}</span>
+                                <span className="ml-2 text-muted-foreground text-xs">
+                                  {f.nik} · {f.farmerGroup.name}
+                                </span>
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Komoditas & Kode Persil */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="commodityCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Komoditas (Opsional)</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value ?? ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Pilih Komoditas" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="none">— Tanpa Komoditas —</SelectItem>
+                        {commodities.map((c) => (
+                          <SelectItem key={c.code} value={c.code}>
+                            {c.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="parcelCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Kode Persil (Opsional)</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Kode Persil" {...field} value={field.value ?? ""} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Luas Polygon & Luas Legal */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="polygonSizeHa"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Luas Polygon (ha) (Opsional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.0001"
+                        min="0"
+                        placeholder="0.0000"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value === "" ? null : e.target.value
+                          )
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="legalSizeHa"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Luas Legal (ha) (Opsional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.0001"
+                        min="0"
+                        placeholder="0.0000"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value === "" ? null : e.target.value
+                          )
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Legal ID & Status */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="legalId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ID Legal (Opsional)</FormLabel>
+                    <FormControl>
+                      <Input placeholder="ID Legal / Sertifikat" {...field} value={field.value ?? ""} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status (Opsional)</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Aktif / Tidak Aktif" {...field} value={field.value ?? ""} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter className="pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isPending}
+              >
+                Batal
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Menyimpan..." : "Simpan"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/admin/master-data/parcels/parcel-list-client.tsx
+++ b/src/app/(admin)/admin/master-data/parcels/parcel-list-client.tsx
@@ -1,0 +1,554 @@
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Plus,
+  Search,
+  Edit2,
+  Trash2,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  ChevronsUpDown,
+  SlidersHorizontal,
+  Eye,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { DeleteDialog } from "@/components/shared/delete-dialog";
+import {
+  deleteLandParcel,
+  type LandParcelRow,
+  type PaginatedParcels,
+  type FarmerDropdownItem,
+  type FarmerGroupDropdownItem,
+  type CommodityDropdownItem,
+} from "@/server/actions/land-parcel";
+import { ParcelFormModal } from "./parcel-form-modal";
+import { ParcelViewModal } from "./parcel-view-modal";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+
+// ─── Debounce hook ────────────────────────────────────────────────────────────
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ParcelListClientProps {
+  initialData: PaginatedParcels;
+  farmers: FarmerDropdownItem[];
+  groups: FarmerGroupDropdownItem[];
+  commodities: CommodityDropdownItem[];
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ParcelListClient({
+  initialData,
+  farmers,
+  groups,
+  commodities,
+}: ParcelListClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [groupFilterOpen, setGroupFilterOpen] = useState(false);
+  const [viewParcel, setViewParcel] = useState<LandParcelRow | null>(null);
+  const [editParcel, setEditParcel] = useState<LandParcelRow | null>(null);
+  const [deleteParcelId, setDeleteParcelId] = useState<string | null>(null);
+
+  const [visibleCols, setVisibleCols] = useState<Set<string>>(
+    new Set(["parcelCode", "farmer", "group", "commodity", "polygonSizeHa", "legalSizeHa", "status"])
+  );
+
+  const toggleColumn = (key: string) => {
+    setVisibleCols((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const currentSearch = searchParams.get("search") || "";
+  const currentGroup = searchParams.get("group") || "all";
+
+  const [searchInput, setSearchInput] = useState(currentSearch);
+  const debouncedSearch = useDebounce(searchInput, 300);
+
+  useEffect(() => {
+    if (debouncedSearch !== currentSearch) {
+      const params = new URLSearchParams(searchParams);
+      if (debouncedSearch) {
+        params.set("search", debouncedSearch);
+      } else {
+        params.delete("search");
+      }
+      params.set("page", "1");
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    }
+  }, [debouncedSearch, currentSearch, pathname, router, searchParams]);
+
+  const handleGroupChange = (value: string | null) => {
+    const params = new URLSearchParams(searchParams);
+    if (value && value !== "all") {
+      params.set("group", value);
+    } else {
+      params.delete("group");
+    }
+    params.set("page", "1");
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
+  };
+
+  const handlePageChange = (newPage: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set("page", newPage.toString());
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!deleteParcelId) return;
+    const result = await deleteLandParcel(deleteParcelId);
+    if (result.success) {
+      toast.success("Persil lahan berhasil dihapus.");
+      setDeleteParcelId(null);
+    } else {
+      toast.error(result.error);
+    }
+  };
+
+  const formatHa = (val: number | null) =>
+    val != null ? `${val.toLocaleString("id-ID", { maximumFractionDigits: 4 })} ha` : "—";
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Data Persil Lahan</h2>
+          <p className="text-muted-foreground">
+            Kelola data persil lahan petani terdaftar.
+          </p>
+        </div>
+        <Button
+          onClick={() => {
+            setEditParcel(null);
+            setModalOpen(true);
+          }}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Tambah Persil
+        </Button>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Filter by farmer group */}
+        <Popover open={groupFilterOpen} onOpenChange={setGroupFilterOpen}>
+          <PopoverTrigger
+            render={
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={groupFilterOpen}
+                className="w-[250px] justify-between h-9"
+              />
+            }
+          >
+            {currentGroup === "all"
+              ? "Semua Kelompok Tani"
+              : groups.find((g) => g.id === currentGroup)?.name ||
+                "Semua Kelompok Tani"}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </PopoverTrigger>
+          <PopoverContent className="w-[280px] p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Cari kelompok tani..." />
+              <CommandList>
+                <CommandEmpty>Kelompok tani tidak ditemukan.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="all"
+                    onSelect={() => {
+                      handleGroupChange("all");
+                      setGroupFilterOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        currentGroup === "all" ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    Semua Kelompok Tani
+                  </CommandItem>
+                  {groups.map((g) => (
+                    <CommandItem
+                      key={g.id}
+                      value={`${g.name} ${g.code ?? ""}`}
+                      onSelect={() => {
+                        handleGroupChange(g.id);
+                        setGroupFilterOpen(false);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          currentGroup === g.id ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      <span>{g.name}</span>
+                      {g.code && (
+                        <span className="ml-2 text-muted-foreground text-xs">
+                          {g.code}
+                        </span>
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {/* Search */}
+        <div className="relative flex-1 min-w-[200px] max-w-sm">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Cari kode persil, nama, atau NIK..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className="pl-8 h-9"
+          />
+        </div>
+
+        {/* Column visibility */}
+        <div className="flex items-center gap-2 ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md bg-background hover:bg-accent hover:text-accent-foreground outline-none transition-colors h-9">
+              <SlidersHorizontal className="h-4 w-4" />
+              Kolom
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Tampilkan Kolom</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("parcelCode")}
+                  onCheckedChange={() => toggleColumn("parcelCode")}
+                >
+                  Kode Persil
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("farmer")}
+                  onCheckedChange={() => toggleColumn("farmer")}
+                >
+                  Nama Petani
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("group")}
+                  onCheckedChange={() => toggleColumn("group")}
+                >
+                  Kelompok Tani
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("commodity")}
+                  onCheckedChange={() => toggleColumn("commodity")}
+                >
+                  Komoditas
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("polygonSizeHa")}
+                  onCheckedChange={() => toggleColumn("polygonSizeHa")}
+                >
+                  Luas Polygon
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("legalSizeHa")}
+                  onCheckedChange={() => toggleColumn("legalSizeHa")}
+                >
+                  Luas Legal
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("legalId")}
+                  onCheckedChange={() => toggleColumn("legalId")}
+                >
+                  ID Legal
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  checked={visibleCols.has("status")}
+                  onCheckedChange={() => toggleColumn("status")}
+                >
+                  Status
+                </DropdownMenuCheckboxItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border bg-card relative">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/70 border-b-2">
+              {visibleCols.has("parcelCode") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Kode Persil
+                </TableHead>
+              )}
+              {visibleCols.has("farmer") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Nama Petani
+                </TableHead>
+              )}
+              {visibleCols.has("group") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Kelompok Tani
+                </TableHead>
+              )}
+              {visibleCols.has("commodity") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Komoditas
+                </TableHead>
+              )}
+              {visibleCols.has("polygonSizeHa") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground text-right">
+                  Luas Polygon
+                </TableHead>
+              )}
+              {visibleCols.has("legalSizeHa") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground text-right">
+                  Luas Legal
+                </TableHead>
+              )}
+              {visibleCols.has("legalId") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  ID Legal
+                </TableHead>
+              )}
+              {visibleCols.has("status") && (
+                <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Status
+                </TableHead>
+              )}
+              <TableHead className="text-right text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Aksi
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {initialData.data.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={visibleCols.size + 1}
+                  className="text-center h-24 text-muted-foreground"
+                >
+                  Belum ada data persil lahan.
+                </TableCell>
+              </TableRow>
+            ) : (
+              initialData.data.map((row) => (
+                <TableRow key={row.id}>
+                  {visibleCols.has("parcelCode") && (
+                    <TableCell className="font-mono text-primary">
+                      {row.parcelCode || "—"}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("farmer") && (
+                    <TableCell className="font-medium">
+                      {row.farmer.name}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("group") && (
+                    <TableCell className="text-muted-foreground">
+                      {row.farmer.farmerGroup.name}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("commodity") && (
+                    <TableCell>
+                      {row.commodity ? (
+                        <Badge variant="outline">{row.commodity.name}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("polygonSizeHa") && (
+                    <TableCell className="text-right tabular-nums">
+                      {formatHa(row.polygonSizeHa)}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("legalSizeHa") && (
+                    <TableCell className="text-right tabular-nums">
+                      {formatHa(row.legalSizeHa)}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("legalId") && (
+                    <TableCell className="font-mono text-muted-foreground text-xs">
+                      {row.legalId || "—"}
+                    </TableCell>
+                  )}
+                  {visibleCols.has("status") && (
+                    <TableCell>
+                      {row.status ? (
+                        <Badge variant="secondary">{row.status}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  )}
+                  <TableCell className="text-right">
+                    <div className="inline-flex items-center gap-1">
+                      <button
+                        title="Lihat Detail"
+                        className="h-8 w-8 inline-flex items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+                        onClick={() => setViewParcel(row)}
+                      >
+                        <Eye className="h-4 w-4" />
+                        <span className="sr-only">Lihat Detail</span>
+                      </button>
+                      <button
+                        title="Edit"
+                        className="h-8 w-8 inline-flex items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+                        onClick={() => {
+                          setEditParcel(row);
+                          setModalOpen(true);
+                        }}
+                      >
+                        <Edit2 className="h-4 w-4" />
+                        <span className="sr-only">Edit</span>
+                      </button>
+                      <button
+                        title="Hapus"
+                        className="h-8 w-8 inline-flex items-center justify-center rounded-md text-red-600 transition-colors hover:bg-red-100 hover:text-red-700 dark:hover:bg-red-950"
+                        onClick={() => setDeleteParcelId(row.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Hapus</span>
+                      </button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {initialData.total > 0 && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            Tampilkan {initialData.data.length} dari {initialData.total} data
+          </span>
+          <div className="flex items-center gap-2">
+            <span>
+              Halaman {initialData.page} dari {initialData.totalPages}
+            </span>
+            <div className="flex gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => handlePageChange(initialData.page - 1)}
+                disabled={initialData.page <= 1 || isPending}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                <span className="sr-only">Sebelumnya</span>
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => handlePageChange(initialData.page + 1)}
+                disabled={initialData.page >= initialData.totalPages || isPending}
+              >
+                <ChevronRight className="h-4 w-4" />
+                <span className="sr-only">Selanjutnya</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* View Modal */}
+      {viewParcel && (
+        <ParcelViewModal
+          parcel={viewParcel}
+          onClose={() => setViewParcel(null)}
+        />
+      )}
+
+      {/* Form Modal */}
+      {modalOpen && (
+        <ParcelFormModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          parcel={editParcel}
+          farmers={farmers}
+          commodities={commodities}
+        />
+      )}
+
+      {/* Delete Dialog */}
+      <DeleteDialog
+        open={!!deleteParcelId}
+        onClose={() => setDeleteParcelId(null)}
+        onConfirm={handleDelete}
+        title="Hapus Persil Lahan"
+        description="Apakah Anda yakin ingin menghapus persil lahan ini? Tindakan ini tidak dapat dibatalkan. Persil yang memiliki data produksi atau pemeliharaan tidak dapat dihapus."
+      />
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/master-data/parcels/parcel-view-modal.tsx
+++ b/src/app/(admin)/admin/master-data/parcels/parcel-view-modal.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import Map, { Layer, Source } from "react-map-gl/maplibre";
+import * as turf from "@turf/turf";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MapPin, AlertCircle } from "lucide-react";
+import {
+  getLandParcelWithGeometry,
+  type LandParcelDetail,
+  type LandParcelRow,
+} from "@/server/actions/land-parcel";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ParcelViewModalProps {
+  parcel: LandParcelRow;
+  onClose: () => void;
+}
+
+// ─── Detail row helper ────────────────────────────────────────────────────────
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex justify-between items-start gap-4 py-2 border-b last:border-0">
+      <span className="text-sm text-muted-foreground shrink-0 w-36">{label}</span>
+      <span className="text-sm font-medium text-right">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+// ─── Map style config ─────────────────────────────────────────────────────────
+
+type MapStyleKey = "light" | "dark" | "satellite";
+
+const MAP_STYLES: Record<MapStyleKey, { label: string; url: string }> = {
+  light: {
+    label: "Light",
+    url: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+  },
+  dark: {
+    label: "Dark",
+    url: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+  },
+  satellite: {
+    label: "Satellite",
+    url: "https://api.maptiler.com/maps/satellite/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL",
+  },
+};
+
+// Satellite uses MapTiler public demo key — replace with project key in production.
+// For seeded/demo data without a key, falls back gracefully to an empty map.
+
+// ─── Map panel ────────────────────────────────────────────────────────────────
+
+function ParcelMap({ detail }: { detail: LandParcelDetail }) {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [activeStyle, setActiveStyle] = useState<MapStyleKey | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Default style follows app theme on first mount
+  const defaultStyle: MapStyleKey =
+    resolvedTheme === "dark" ? "dark" : "light";
+  const currentStyle = activeStyle ?? defaultStyle;
+
+  // Derive initial view from polygon bbox or center point
+  const initialView = (() => {
+    if (detail.polygonGeoJson) {
+      const center = turf.center(detail.polygonGeoJson);
+      const bbox = turf.bbox(detail.polygonGeoJson);
+      const [lng, lat] = center.geometry.coordinates;
+      const lngSpan = bbox[2] - bbox[0];
+      const zoom = lngSpan < 0.005 ? 15 : lngSpan < 0.02 ? 13 : 11;
+      return { longitude: lng, latitude: lat, zoom };
+    }
+    if (detail.centerPointGeoJson) {
+      const [lng, lat] = detail.centerPointGeoJson.coordinates;
+      return { longitude: lng, latitude: lat, zoom: 14 };
+    }
+    return { longitude: 101.44, latitude: 0.53, zoom: 7 };
+  })();
+
+  const hasGeometry = !!(detail.polygonGeoJson || detail.centerPointGeoJson);
+
+  // Polygon stroke is white on satellite for contrast, green on light/dark
+  const strokeColor = currentStyle === "satellite" ? "#ffffff" : "#16a34a";
+  const fillColor = currentStyle === "satellite" ? "#ffffff" : "#22c55e";
+
+  if (!mounted) {
+    return <Skeleton className="h-full w-full rounded-none" />;
+  }
+
+  return (
+    <div className="relative h-full w-full">
+      <Map
+        initialViewState={initialView}
+        mapStyle={MAP_STYLES[currentStyle].url}
+        attributionControl={false}
+        style={{ width: "100%", height: "100%" }}
+      >
+        {/* Polygon fill + outline */}
+        {detail.polygonGeoJson && (
+          <Source
+            id="parcel-polygon"
+            type="geojson"
+            data={{
+              type: "Feature",
+              geometry: detail.polygonGeoJson,
+              properties: {},
+            }}
+          >
+            <Layer
+              id="parcel-fill"
+              type="fill"
+              paint={{ "fill-color": fillColor, "fill-opacity": 0.25 }}
+            />
+            <Layer
+              id="parcel-outline"
+              type="line"
+              paint={{ "line-color": strokeColor, "line-width": 2 }}
+            />
+          </Source>
+        )}
+
+        {/* Center point fallback */}
+        {!detail.polygonGeoJson && detail.centerPointGeoJson && (
+          <Source
+            id="parcel-center"
+            type="geojson"
+            data={{
+              type: "Feature",
+              geometry: detail.centerPointGeoJson,
+              properties: {},
+            }}
+          >
+            <Layer
+              id="parcel-center-circle"
+              type="circle"
+              paint={{
+                "circle-radius": 8,
+                "circle-color": "#16a34a",
+                "circle-opacity": 0.8,
+                "circle-stroke-width": 2,
+                "circle-stroke-color": "#fff",
+              }}
+            />
+          </Source>
+        )}
+      </Map>
+
+      {/* Style switcher — top-left */}
+      <div className="absolute top-2 left-2 flex gap-1 z-10">
+        {(Object.keys(MAP_STYLES) as MapStyleKey[]).map((key) => (
+          <button
+            key={key}
+            onClick={() => setActiveStyle(key)}
+            className={`px-2.5 py-1 rounded text-xs font-semibold shadow border transition-colors ${
+              currentStyle === key
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background/90 text-foreground border-border hover:bg-accent"
+            }`}
+          >
+            {MAP_STYLES[key].label}
+          </button>
+        ))}
+      </div>
+
+      {/* No geometry notice */}
+      {!hasGeometry && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-muted/60 backdrop-blur-sm">
+          <MapPin className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground font-medium">
+            Belum ada data geometri
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Polygon akan dikelola melalui GIS Tools (Fase 6)
+          </p>
+        </div>
+      )}
+
+      {/* Attribution */}
+      <div className="absolute bottom-2 right-2 bg-background/80 backdrop-blur-sm px-2 py-1 rounded text-[10px] font-medium border shadow-sm pointer-events-none">
+        © CartoDB / MapTiler
+      </div>
+    </div>
+  );
+}
+
+// ─── Main modal ───────────────────────────────────────────────────────────────
+
+export function ParcelViewModal({ parcel, onClose }: ParcelViewModalProps) {
+  const [detail, setDetail] = useState<LandParcelDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getLandParcelWithGeometry(parcel.id).then((result) => {
+      if (result.success && result.data) {
+        setDetail(result.data);
+      } else {
+        setError(!result.success ? result.error : "Gagal memuat data.");
+      }
+      setLoading(false);
+    });
+  }, [parcel.id]);
+
+  const formatHa = (val: number | null) =>
+    val != null
+      ? `${val.toLocaleString("id-ID", { maximumFractionDigits: 4 })} ha`
+      : null;
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[820px] max-h-[90vh] p-0 overflow-hidden flex flex-col">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b shrink-0">
+          <DialogTitle className="flex items-center gap-2">
+            Detail Persil Lahan
+            {parcel.parcelCode && (
+              <span className="font-mono text-primary text-base">
+                — {parcel.parcelCode}
+              </span>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex-1 p-6 space-y-3">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-[300px] w-full mt-4" />
+          </div>
+        ) : error ? (
+          <div className="flex-1 flex items-center justify-center gap-2 text-destructive p-6">
+            <AlertCircle className="h-5 w-5" />
+            <span className="text-sm">{error}</span>
+          </div>
+        ) : detail ? (
+          <div className="flex-1 overflow-y-auto">
+            {/* Two-column layout: info left, map right */}
+            <div className="flex flex-col sm:flex-row min-h-0">
+              {/* Info panel */}
+              <div className="sm:w-[300px] shrink-0 px-6 py-4 border-b sm:border-b-0 sm:border-r">
+                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                  Informasi Persil
+                </p>
+                <div>
+                  <DetailRow label="Petani" value={detail.farmer.name} />
+                  <DetailRow
+                    label="Kelompok Tani"
+                    value={detail.farmer.farmerGroup.name}
+                  />
+                  <DetailRow
+                    label="Komoditas"
+                    value={
+                      detail.commodity ? (
+                        <Badge variant="outline">{detail.commodity.name}</Badge>
+                      ) : null
+                    }
+                  />
+                  <DetailRow label="Kode Persil" value={detail.parcelCode} />
+                  <DetailRow label="WRI Parcel ID" value={detail.wriParcelId} />
+                  <DetailRow
+                    label="Luas Polygon"
+                    value={formatHa(detail.polygonSizeHa)}
+                  />
+                  <DetailRow
+                    label="Luas Legal"
+                    value={formatHa(detail.legalSizeHa)}
+                  />
+                  <DetailRow label="ID Legal" value={detail.legalId} />
+                  <DetailRow
+                    label="Status"
+                    value={
+                      detail.status ? (
+                        <Badge variant="secondary">{detail.status}</Badge>
+                      ) : null
+                    }
+                  />
+                  <DetailRow label="Revisi" value={detail.revision} />
+                </div>
+
+                {/* Geometry status */}
+                <div className="mt-4 pt-3 border-t">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    Geometri
+                  </p>
+                  <div className="flex flex-col gap-1.5">
+                    <div className="flex items-center gap-2 text-xs">
+                      <span
+                        className={`h-2 w-2 rounded-full ${detail.polygonGeoJson ? "bg-green-500" : "bg-muted-foreground/40"}`}
+                      />
+                      <span className="text-muted-foreground">
+                        Polygon:{" "}
+                        {detail.polygonGeoJson ? (
+                          <span className="text-green-600 font-medium">
+                            Tersedia
+                          </span>
+                        ) : (
+                          "Belum ada"
+                        )}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs">
+                      <span
+                        className={`h-2 w-2 rounded-full ${detail.centerPointGeoJson ? "bg-green-500" : "bg-muted-foreground/40"}`}
+                      />
+                      <span className="text-muted-foreground">
+                        Titik Pusat:{" "}
+                        {detail.centerPointGeoJson ? (
+                          <span className="text-green-600 font-medium">
+                            Tersedia
+                          </span>
+                        ) : (
+                          "Belum ada"
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Map panel */}
+              <div className="flex-1 h-[340px] sm:h-auto min-h-[300px]">
+                <ParcelMap detail={detail} />
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/server/actions/land-parcel.ts
+++ b/src/server/actions/land-parcel.ts
@@ -1,0 +1,359 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { landParcelSchema, LandParcelFormValues } from "@/validations/land-parcel.schema";
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/types/action-result";
+import { Prisma } from "@prisma/client";
+
+const REVALIDATE_PATH = "/admin/master-data/parcels";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface LandParcelRow {
+  id: string;
+  farmerId: string;
+  farmer: {
+    name: string;
+    nik: string;
+    farmerGroup: { name: string };
+  };
+  commodityCode: string | null;
+  commodity: { name: string } | null;
+  wriParcelId: string | null;
+  parcelCode: string | null;
+  revision: number;
+  polygonSizeHa: number | null;
+  legalId: string | null;
+  legalSizeHa: number | null;
+  status: string | null;
+  _count: {
+    productions: number;
+    maintenances: number;
+  };
+}
+
+export interface PaginatedParcels {
+  data: LandParcelRow[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
+export interface FarmerDropdownItem {
+  id: string;
+  name: string;
+  nik: string;
+  farmerGroup: { name: string };
+}
+
+export interface FarmerGroupDropdownItem {
+  id: string;
+  name: string;
+  code: string | null;
+}
+
+export interface CommodityDropdownItem {
+  code: string;
+  name: string;
+}
+
+// ─── Read ────────────────────────────────────────────────────────────────────
+
+export async function getLandParcels(
+  page: number = 1,
+  limit: number = 10,
+  search?: string,
+  farmerGroupId?: string
+): Promise<ActionResult<PaginatedParcels>> {
+  try {
+    const where: Prisma.LandParcelWhereInput = {};
+
+    if (search) {
+      where.OR = [
+        { parcelCode: { contains: search, mode: "insensitive" } },
+        { farmer: { name: { contains: search, mode: "insensitive" } } },
+        { farmer: { nik: { contains: search } } },
+      ];
+    }
+
+    if (farmerGroupId) {
+      where.farmer = { farmerGroupId };
+    }
+
+    const total = await prisma.landParcel.count({ where });
+    const totalPages = Math.ceil(total / limit) || 1;
+    const offset = (page - 1) * limit;
+
+    const data = await prisma.landParcel.findMany({
+      where,
+      orderBy: { farmer: { name: "asc" } },
+      skip: offset,
+      take: limit,
+      select: {
+        id: true,
+        farmerId: true,
+        farmer: {
+          select: {
+            name: true,
+            nik: true,
+            farmerGroup: { select: { name: true } },
+          },
+        },
+        commodityCode: true,
+        commodity: { select: { name: true } },
+        wriParcelId: true,
+        parcelCode: true,
+        revision: true,
+        polygonSizeHa: true,
+        legalId: true,
+        legalSizeHa: true,
+        status: true,
+        _count: {
+          select: {
+            productions: true,
+            maintenances: true,
+          },
+        },
+      },
+    });
+
+    return {
+      success: true,
+      data: {
+        data: data as unknown as LandParcelRow[],
+        total,
+        page,
+        totalPages,
+      },
+    };
+  } catch (error) {
+    console.error("Failed to fetch land parcels:", error);
+    return { success: false, error: "Gagal memuat data persil lahan." };
+  }
+}
+
+// ─── View with geometry (raw SQL for PostGIS) ────────────────────────────────
+
+export interface LandParcelDetail extends LandParcelRow {
+  polygonGeoJson: GeoJSON.Polygon | null;
+  centerPointGeoJson: GeoJSON.Point | null;
+}
+
+export async function getLandParcelWithGeometry(
+  id: string
+): Promise<ActionResult<LandParcelDetail>> {
+  try {
+    // Fetch scalar fields via Prisma
+    const base = await prisma.landParcel.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        farmerId: true,
+        farmer: {
+          select: {
+            name: true,
+            nik: true,
+            farmerGroup: { select: { name: true } },
+          },
+        },
+        commodityCode: true,
+        commodity: { select: { name: true } },
+        wriParcelId: true,
+        parcelCode: true,
+        revision: true,
+        polygonSizeHa: true,
+        legalId: true,
+        legalSizeHa: true,
+        status: true,
+        _count: {
+          select: {
+            productions: true,
+            maintenances: true,
+          },
+        },
+      },
+    });
+
+    if (!base) return { success: false, error: "Persil lahan tidak ditemukan." };
+
+    // Fetch geometry as GeoJSON via raw SQL (PostGIS Unsupported fields)
+    const geoRows = await prisma.$queryRaw<
+      Array<{ polygon_geojson: string | null; center_geojson: string | null }>
+    >`
+      SELECT
+        ST_AsGeoJSON(polygon)     AS polygon_geojson,
+        ST_AsGeoJSON("centerPoint") AS center_geojson
+      FROM "tbl-land-parcel"
+      WHERE id = ${id}
+    `;
+
+    const geo = geoRows[0] ?? { polygon_geojson: null, center_geojson: null };
+
+    return {
+      success: true,
+      data: {
+        ...(base as unknown as LandParcelRow),
+        polygonGeoJson: geo.polygon_geojson
+          ? (JSON.parse(geo.polygon_geojson) as GeoJSON.Polygon)
+          : null,
+        centerPointGeoJson: geo.center_geojson
+          ? (JSON.parse(geo.center_geojson) as GeoJSON.Point)
+          : null,
+      },
+    };
+  } catch (error) {
+    console.error("Failed to fetch land parcel with geometry:", error);
+    return { success: false, error: "Gagal memuat data persil lahan." };
+  }
+}
+
+// ─── Create ──────────────────────────────────────────────────────────────────
+
+export async function createLandParcel(
+  data: LandParcelFormValues
+): Promise<ActionResult> {
+  try {
+    const validated = landParcelSchema.parse(data);
+
+    await prisma.landParcel.create({
+      data: {
+        farmerId: validated.farmerId,
+        commodityCode: validated.commodityCode || null,
+        parcelCode: validated.parcelCode || null,
+        polygonSizeHa: validated.polygonSizeHa ?? null,
+        legalId: validated.legalId || null,
+        legalSizeHa: validated.legalSizeHa ?? null,
+        status: validated.status || null,
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error: any) {
+    console.error("Failed to create land parcel:", error);
+    return { success: false, error: error.message || "Gagal membuat persil lahan." };
+  }
+}
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+export async function updateLandParcel(
+  id: string,
+  data: LandParcelFormValues
+): Promise<ActionResult> {
+  try {
+    const validated = landParcelSchema.parse(data);
+
+    await prisma.landParcel.update({
+      where: { id },
+      data: {
+        farmerId: validated.farmerId,
+        commodityCode: validated.commodityCode || null,
+        parcelCode: validated.parcelCode || null,
+        polygonSizeHa: validated.polygonSizeHa ?? null,
+        legalId: validated.legalId || null,
+        legalSizeHa: validated.legalSizeHa ?? null,
+        status: validated.status || null,
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error: any) {
+    console.error("Failed to update land parcel:", error);
+    return { success: false, error: error.message || "Gagal mengupdate persil lahan." };
+  }
+}
+
+// ─── Delete ──────────────────────────────────────────────────────────────────
+
+export async function deleteLandParcel(id: string): Promise<ActionResult> {
+  try {
+    const parcel = await prisma.landParcel.findUnique({
+      where: { id },
+      select: {
+        _count: {
+          select: {
+            productions: true,
+            maintenances: true,
+          },
+        },
+      },
+    });
+
+    if (!parcel) {
+      return { success: false, error: "Persil lahan tidak ditemukan." };
+    }
+
+    const totalRelated =
+      parcel._count.productions + parcel._count.maintenances;
+
+    if (totalRelated > 0) {
+      return {
+        success: false,
+        error: `Tidak dapat menghapus. Persil lahan masih memiliki ${parcel._count.productions} data produksi dan ${parcel._count.maintenances} data pemeliharaan.`,
+      };
+    }
+
+    await prisma.landParcel.delete({ where: { id } });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error: any) {
+    console.error("Failed to delete land parcel:", error);
+    return { success: false, error: "Gagal menghapus persil lahan." };
+  }
+}
+
+// ─── Dropdowns ───────────────────────────────────────────────────────────────
+
+export async function getFarmersForDropdown(): Promise<
+  ActionResult<FarmerDropdownItem[]>
+> {
+  try {
+    const farmers = await prisma.farmer.findMany({
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        name: true,
+        nik: true,
+        farmerGroup: { select: { name: true } },
+      },
+    });
+    return { success: true, data: farmers };
+  } catch (error) {
+    console.error("Failed to fetch farmers for dropdown:", error);
+    return { success: false, error: "Gagal memuat data petani." };
+  }
+}
+
+export async function getFarmerGroupsForDropdown(): Promise<
+  ActionResult<FarmerGroupDropdownItem[]>
+> {
+  try {
+    const groups = await prisma.farmerGroup.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true, code: true },
+    });
+    return { success: true, data: groups };
+  } catch (error) {
+    console.error("Failed to fetch farmer groups for dropdown:", error);
+    return { success: false, error: "Gagal memuat data kelompok tani." };
+  }
+}
+
+export async function getCommodities(): Promise<
+  ActionResult<CommodityDropdownItem[]>
+> {
+  try {
+    const commodities = await prisma.commodity.findMany({
+      orderBy: { name: "asc" },
+      select: { code: true, name: true },
+    });
+    return { success: true, data: commodities };
+  } catch (error) {
+    console.error("Failed to fetch commodities:", error);
+    return { success: false, error: "Gagal memuat data komoditas." };
+  }
+}

--- a/src/test/land-parcel.test.ts
+++ b/src/test/land-parcel.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { landParcelSchema } from "../validations/land-parcel.schema";
+
+describe("LandParcel Schema Validation", () => {
+  // ─── Valid cases ──────────────────────────────────────────────────────────
+
+  it("should accept a minimal valid parcel (farmerId only)", () => {
+    const result = landParcelSchema.safeParse({ farmerId: "farmer-1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a fully populated valid parcel", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      commodityCode: "PALM",
+      parcelCode: "P-001",
+      polygonSizeHa: 2.5,
+      legalId: "SHM-12345",
+      legalSizeHa: 2.0,
+      status: "Aktif",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.polygonSizeHa).toBe(2.5);
+      expect(result.data.legalSizeHa).toBe(2.0);
+    }
+  });
+
+  it("should accept empty strings for optional fields and transform them to null", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      commodityCode: "",
+      parcelCode: "",
+      polygonSizeHa: "",
+      legalId: "",
+      legalSizeHa: "",
+      status: "",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.polygonSizeHa).toBeNull();
+      expect(result.data.legalSizeHa).toBeNull();
+    }
+  });
+
+  it("should accept null for optional numeric fields", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      polygonSizeHa: null,
+      legalSizeHa: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.polygonSizeHa).toBeNull();
+      expect(result.data.legalSizeHa).toBeNull();
+    }
+  });
+
+  it("should coerce string numbers to floats for size fields", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      polygonSizeHa: "1.75",
+      legalSizeHa: "1.50",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.polygonSizeHa).toBe(1.75);
+      expect(result.data.legalSizeHa).toBe(1.5);
+    }
+  });
+
+  // ─── Invalid cases ────────────────────────────────────────────────────────
+
+  it("should reject missing farmerId", () => {
+    const result = landParcelSchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const farmerIdError = result.error.issues.find(
+        (i) => i.path[0] === "farmerId"
+      );
+      expect(farmerIdError).toBeDefined();
+      // Zod emits a type error when field is undefined; min(1) message fires on empty string
+    }
+  });
+
+  it("should reject empty string farmerId", () => {
+    const result = landParcelSchema.safeParse({ farmerId: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const farmerIdError = result.error.issues.find(
+        (i) => i.path[0] === "farmerId"
+      );
+      expect(farmerIdError).toBeDefined();
+    }
+  });
+
+  it("should reject negative polygonSizeHa", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      polygonSizeHa: -1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const sizeError = result.error.issues.find(
+        (i) => i.path[0] === "polygonSizeHa"
+      );
+      expect(sizeError).toBeDefined();
+      expect(sizeError?.message).toContain("positif");
+    }
+  });
+
+  it("should reject zero polygonSizeHa (must be positive)", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      polygonSizeHa: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject negative legalSizeHa", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      legalSizeHa: -0.5,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const sizeError = result.error.issues.find(
+        (i) => i.path[0] === "legalSizeHa"
+      );
+      expect(sizeError).toBeDefined();
+      expect(sizeError?.message).toContain("positif");
+    }
+  });
+
+  it("should reject non-numeric string for size fields", () => {
+    const result = landParcelSchema.safeParse({
+      farmerId: "farmer-1",
+      polygonSizeHa: "abc",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ─── Pagination logic ─────────────────────────────────────────────────────
+
+  it("Pagination: total 0, limit 10 -> totalPages = 1 (floor guard)", () => {
+    const total = 0;
+    const limit = 10;
+    const totalPages = Math.ceil(total / limit) || 1;
+    expect(totalPages).toBe(1);
+  });
+
+  it("Pagination: total 25, limit 10 -> totalPages = 3", () => {
+    const total = 25;
+    const limit = 10;
+    const totalPages = Math.ceil(total / limit) || 1;
+    expect(totalPages).toBe(3);
+  });
+
+  it("Pagination: total 10, limit 10 -> totalPages = 1", () => {
+    const total = 10;
+    const limit = 10;
+    const totalPages = Math.ceil(total / limit) || 1;
+    expect(totalPages).toBe(1);
+  });
+
+  // ─── Delete guard logic ───────────────────────────────────────────────────
+
+  it("Delete guard: should block deletion when related records exist", () => {
+    const mockParcel = { _count: { productions: 2, maintenances: 1 } };
+    const totalRelated =
+      mockParcel._count.productions + mockParcel._count.maintenances;
+    expect(totalRelated).toBeGreaterThan(0);
+  });
+
+  it("Delete guard: should allow deletion when no related records", () => {
+    const mockParcel = { _count: { productions: 0, maintenances: 0 } };
+    const totalRelated =
+      mockParcel._count.productions + mockParcel._count.maintenances;
+    expect(totalRelated).toBe(0);
+  });
+});

--- a/src/validations/land-parcel.schema.ts
+++ b/src/validations/land-parcel.schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * Preprocessor that converts empty strings and null to undefined/null,
+ * and coerces valid values to positive numbers.
+ */
+const optionalPositiveNumber = z
+  .union([z.null(), z.literal(""), z.coerce.number().positive("Luas harus positif")])
+  .optional()
+  .transform((val) => (val === "" ? null : val));
+
+export const landParcelSchema = z.object({
+  id: z.string().optional(),
+  farmerId: z.string().min(1, "Petani wajib dipilih"),
+  commodityCode: z.string().optional().or(z.literal("")),
+  parcelCode: z.string().optional().or(z.literal("")),
+  polygonSizeHa: optionalPositiveNumber,
+  legalId: z.string().optional().or(z.literal("")),
+  legalSizeHa: optionalPositiveNumber,
+  status: z.string().optional().or(z.literal("")),
+});
+
+export type LandParcelFormValues = z.infer<typeof landParcelSchema>;


### PR DESCRIPTION
… + map

- Add Zod schema: src/validations/land-parcel.schema.ts
  - farmerId required, optional numeric fields with positive validation
  - empty string → null transform for ha fields

- Add server actions: src/server/actions/land-parcel.ts
  - getLandParcels (paginated, filter by farmerGroupId, search)
  - createLandParcel / updateLandParcel / deleteLandParcel
  - deleteLandParcel guards against agronomy data (productions + maintenances)
  - getLandParcelWithGeometry: raw SQL ST_AsGeoJSON for PostGIS polygon/centerPoint
  - getFarmersForDropdown, getFarmerGroupsForDropdown, getCommodities

- Add page: src/app/(admin)/admin/master-data/parcels/page.tsx
  - Server Component, parallel fetch, Card wrapper, page header

- Add parcel-list-client.tsx
  - Filter by kelompok tani (searchable combobox)
  - Debounced search (kode persil / nama / NIK)
  - Column visibility toggle, server-side pagination
  - Eye / Edit / Delete action buttons

- Add parcel-form-modal.tsx
  - Petani searchable combobox (nama + NIK + kelompok)
  - Komoditas dropdown, luas ha fields, status
  - Toast success/error feedback

- Add parcel-view-modal.tsx
  - Detail panel (all scalar fields + geometry status indicators)
  - MapLibre map with polygon fill + outline (PostGIS GeoJSON)
  - Map style switcher: Light / Dark / Satellite
  - Polygon stroke adapts to satellite (white) vs light/dark (green)
  - Graceful fallback when no geometry data

- Add unit tests: src/test/land-parcel.test.ts (16 tests)
  - Schema valid/invalid cases, luas negatif/nol rejected
  - Pagination logic, delete guard logic

- Update docs/rule&progress.md: mark #21 ✅, update changelog

Closes #21