### PR TITLE
feat(#41): Master Data Staff WRI — List, Detail, CRUD, Job Desk, Penugasan

### DIFF
--- a/docs/rule&progress.md
+++ b/docs/rule&progress.md
@@ -12,7 +12,7 @@
 | **Proyek** | Smallholder HUB — Management Information System |
 | **Stack** | Next.js 16 · React 19 · Tailwind 4 · Shadcn UI · Prisma 7 · MapLibre |
 | **Repository** | `WRI-Indonesia/mis-smallholder-hub` |
-| **Terakhir Diupdate** | 2026-05-08 |
+| **Terakhir Diupdate** | 2026-05-09 |
 | **Diupdate Oleh** | Sofyan (via AI-assisted development) |
 | **Branch Aktif** | `dev-phase-4` |
 
@@ -102,7 +102,7 @@ Fase 1 ✅ → Fase 2 ✅ → DB Hardening → Fase 4 (Master Data) → Fase 3 (
 | **3** | Autentikasi & RBAC | ⏭️ Skipped | — | — |
 | **4** | Master Data CRUD | ✅ Selesai | [#17](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/17) Shared Infra ✅ · [#18](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/18) Regions ✅ · [#19](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/19) Groups ✅ · [#20](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/20) Farmers ✅ · [#21](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/21) Parcels ✅ · [#22](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/22) Final QA ✅ | [Milestone #3](https://github.com/WRI-Indonesia/mis-smallholder-hub/milestone/3) |
 | **4.a Infra** | Dynamic Menu Management — DB-driven Sidebar + Menu CRUD Settings | ✅ Selesai | [#35](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/35) Dynamic Menu Management ✅ | [Milestone #6](https://github.com/WRI-Indonesia/mis-smallholder-hub/milestone/6) |
-| **4.a** | Master Data CRUD - Phase 2 (Training, Agronomy) | 🔄 In Progress | [#39](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/39) Training List & Detail ✅ | — || **4.b** | Master Data CRUD - Phase 3 (HCV, BUSDEV) | 🔲 | — | — |
+| **4.a** | Master Data CRUD - Phase 2 (Training, Agronomy) | 🔄 In Progress | [#39](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/39) Training List & Detail ✅ · [#41](https://github.com/WRI-Indonesia/mis-smallholder-hub/issues/41) Staff WRI List & Detail ✅ | — || **4.b** | Master Data CRUD - Phase 3 (HCV, BUSDEV) | 🔲 | — | — |
 | **4.c** | Master Data CRUD - Phase 4 (IMPACT, Workplan) | 🔲 | — | — |
 | **5** | CMS & Content Management | 🔲 | — | — |
 | **6** | Tools (Import/Export/GIS) | 🔲 | — | — |
@@ -119,6 +119,7 @@ Fase 1 ✅ → Fase 2 ✅ → DB Hardening → Fase 4 (Master Data) → Fase 3 (
 
 | Tanggal & Waktu | Perubahan |
 |-----------------|-----------|
+| 2026-05-09 12:20 | Issue #41 selesai — Master Data Staff WRI: Prisma schema 4 model baru (`JobDesk`, `Staff`, `StaffDistrict`, `StaffFarmerGroup`), migration SQL manual, seed 8 job desks, seed menu entry `md-staff`. Server actions: `getStaff`, `getStaffById`, `createStaff`, `updateStaff`, `deleteStaff`, `getJobDesksForDropdown`, `getStaffForDropdown`. List page (DataTable + filter Job Desk searchable combobox + tombol Tambah Staff). Form modal create/edit: Job Desk combobox (`shouldFilter=false`), Line Manager searchable (exclude self), multi-select Distrik + KT dengan Pilih Semua shortcut + badge preview, pre-populate saat edit via `getStaffById`. Detail page: profil + direct reports clickable + tabel distrik + tabel KT. Kosong = semua (distrik/KT). 14 unit tests. Build ✅, Tests 130/130 ✅. |
 | 2026-05-08 21:00 | Issue #39 selesai (final) — Training module lengkap: List page (DataTable + filter KT searchable combobox + tombol Tambah Kegiatan), Form modal create/edit (KT + paket searchable, tanggal, lokasi, upload PDF evidence ke S3 bucket mis-dev dengan presigned URL), Detail page (summary card + daftar peserta + tombol Tambah Peserta dual-panel modal + hapus peserta), server actions: `getTrainingActivities`, `getTrainingActivityById`, `createTrainingActivity`, `updateTrainingActivity`, `deleteTrainingActivity`, `addParticipants`, `removeParticipant`, `getFarmersByGroup`, `uploadTrainingEvidence`. S3 lib (`src/lib/s3.ts`): presigned URL 7 hari. Build ✅, Tests 116/116 ✅. |
 | 2026-05-08 19:45 | Issue #39 selesai — Master Data Training List & Detail: server action `getTrainingActivities` + `getTrainingActivityById` + `deleteTrainingActivity`, list page dengan DataTable (6 kolom: KT, paket, tanggal, lokasi, peserta, evidence link), detail page (summary card + tabel peserta dengan NIK masking), delete dengan konfirmasi dialog + router.refresh, placeholder Edit (toast info), 17 unit tests baru (schema validation, pagination, date formatting, NIK masking). Build ✅, Tests 117/117 ✅. |
 | 2026-05-08 16:45 | Issue #37 selesai — Interactive Map Dashboard: filter kabupaten + multi-select KT mempengaruhi map & ringkasan, panel section jadi collapsible (Filter/Layer/Basemap), marker KT non-cluster pakai icon. Build ✅, Tests 100/100 ✅. |

--- a/prisma/migrations/20260509000000_add_staff/migration.sql
+++ b/prisma/migrations/20260509000000_add_staff/migration.sql
@@ -1,0 +1,108 @@
+-- Migration: add_staff
+-- Issue #41 — Master Data Staff WRI
+-- Creates ref-job-desk, tbl-staff, tbl-staff-district, tbl-staff-farmer-group
+
+-- ─── ref-job-desk ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "ref-job-desk" (
+    "id"          TEXT NOT NULL,
+    "code"        TEXT NOT NULL,
+    "name"        TEXT NOT NULL,
+
+    CONSTRAINT "ref-job-desk_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ref-job-desk_code_key" ON "ref-job-desk"("code");
+
+-- ─── tbl-staff ────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "tbl-staff" (
+    "id"              TEXT NOT NULL,
+    "staff_code"      TEXT NOT NULL,
+    "name"            TEXT NOT NULL,
+    "job_desk_id"     TEXT NOT NULL,
+    "email_wri"       TEXT,
+    "line_manager_id" TEXT,
+    "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by"      TEXT,
+    "modified_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified_by"     TEXT,
+
+    CONSTRAINT "tbl-staff_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "tbl-staff_staff_code_key" ON "tbl-staff"("staff_code");
+
+ALTER TABLE "tbl-staff"
+    ADD CONSTRAINT "tbl-staff_job_desk_id_fkey"
+    FOREIGN KEY ("job_desk_id")
+    REFERENCES "ref-job-desk"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "tbl-staff"
+    ADD CONSTRAINT "tbl-staff_line_manager_id_fkey"
+    FOREIGN KEY ("line_manager_id")
+    REFERENCES "tbl-staff"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "tbl-staff"
+    ADD CONSTRAINT "tbl-staff_created_by_fkey"
+    FOREIGN KEY ("created_by")
+    REFERENCES "tbl-user"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "tbl-staff"
+    ADD CONSTRAINT "tbl-staff_modified_by_fkey"
+    FOREIGN KEY ("modified_by")
+    REFERENCES "tbl-user"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ─── tbl-staff-district ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "tbl-staff-district" (
+    "id"          TEXT NOT NULL,
+    "staff_id"    TEXT NOT NULL,
+    "district_id" TEXT NOT NULL,
+
+    CONSTRAINT "tbl-staff-district_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "tbl-staff-district_staff_id_district_id_key"
+    ON "tbl-staff-district"("staff_id", "district_id");
+
+ALTER TABLE "tbl-staff-district"
+    ADD CONSTRAINT "tbl-staff-district_staff_id_fkey"
+    FOREIGN KEY ("staff_id")
+    REFERENCES "tbl-staff"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "tbl-staff-district"
+    ADD CONSTRAINT "tbl-staff-district_district_id_fkey"
+    FOREIGN KEY ("district_id")
+    REFERENCES "reg-district"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ─── tbl-staff-farmer-group ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "tbl-staff-farmer-group" (
+    "id"              TEXT NOT NULL,
+    "staff_id"        TEXT NOT NULL,
+    "farmer_group_id" TEXT NOT NULL,
+
+    CONSTRAINT "tbl-staff-farmer-group_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "tbl-staff-farmer-group_staff_id_farmer_group_id_key"
+    ON "tbl-staff-farmer-group"("staff_id", "farmer_group_id");
+
+ALTER TABLE "tbl-staff-farmer-group"
+    ADD CONSTRAINT "tbl-staff-farmer-group_staff_id_fkey"
+    FOREIGN KEY ("staff_id")
+    REFERENCES "tbl-staff"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "tbl-staff-farmer-group"
+    ADD CONSTRAINT "tbl-staff-farmer-group_farmer_group_id_fkey"
+    FOREIGN KEY ("farmer_group_id")
+    REFERENCES "tbl-farmer-group"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema/farmer-group.prisma
+++ b/prisma/schema/farmer-group.prisma
@@ -29,6 +29,7 @@ model FarmerGroup {
   farmers      Farmer[]
   trainings    TrainingActivity[]
   certifications Certification[]
+  staffs       StaffFarmerGroup[]
 
   createdAt      DateTime @default(now()) @map("created_at")
   createdBy      String?  @map("created_by")

--- a/prisma/schema/geography.prisma
+++ b/prisma/schema/geography.prisma
@@ -17,6 +17,7 @@ model District {
   name         String
   subdistricts Subdistrict[]
   farmerGroups FarmerGroup[]
+  staffs       StaffDistrict[]
 
   @@map("reg-district")
 }

--- a/prisma/schema/staff.prisma
+++ b/prisma/schema/staff.prisma
@@ -1,0 +1,57 @@
+// staff.prisma — WRI Staff, JobDesk, and assignment models
+
+model JobDesk {
+  id    String  @id @default(cuid())
+  code  String  @unique
+  name  String
+  staff Staff[]
+
+  @@map("ref-job-desk")
+}
+
+model Staff {
+  id            String  @id @default(cuid())
+  staffCode     String  @unique @map("staff_code")
+  name          String
+  jobDeskId     String  @map("job_desk_id")
+  jobDesk       JobDesk @relation(fields: [jobDeskId], references: [id])
+  emailWri      String? @map("email_wri")
+  lineManagerId String? @map("line_manager_id")
+  lineManager   Staff?  @relation("StaffLineManager", fields: [lineManagerId], references: [id])
+  directReports Staff[] @relation("StaffLineManager")
+
+  // Many-to-many assignments
+  districts    StaffDistrict[]
+  farmerGroups StaffFarmerGroup[]
+
+  createdAt      DateTime @default(now()) @map("created_at")
+  createdBy      String?  @map("created_by")
+  createdByUser  User?    @relation("StaffCreatedBy", fields: [createdBy], references: [id])
+  modifiedAt     DateTime @updatedAt @map("modified_at")
+  modifiedBy     String?  @map("modified_by")
+  modifiedByUser User?    @relation("StaffModifiedBy", fields: [modifiedBy], references: [id])
+
+  @@map("tbl-staff")
+}
+
+model StaffDistrict {
+  id         String   @id @default(cuid())
+  staffId    String   @map("staff_id")
+  staff      Staff    @relation(fields: [staffId], references: [id])
+  districtId String   @map("district_id")
+  district   District @relation(fields: [districtId], references: [id])
+
+  @@unique([staffId, districtId])
+  @@map("tbl-staff-district")
+}
+
+model StaffFarmerGroup {
+  id            String      @id @default(cuid())
+  staffId       String      @map("staff_id")
+  staff         Staff       @relation(fields: [staffId], references: [id])
+  farmerGroupId String      @map("farmer_group_id")
+  farmerGroup   FarmerGroup @relation(fields: [farmerGroupId], references: [id])
+
+  @@unique([staffId, farmerGroupId])
+  @@map("tbl-staff-farmer-group")
+}

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -76,6 +76,9 @@ model User {
   // AuditEvidence
   auditEvidencesCreated   AuditEvidence[] @relation("AuditEvidenceCreatedBy")
   auditEvidencesModified  AuditEvidence[] @relation("AuditEvidenceModifiedBy")
+  // Staff
+  staffCreated   Staff[] @relation("StaffCreatedBy")
+  staffModified  Staff[] @relation("StaffModifiedBy")
 
   @@map("tbl-user")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -26,6 +26,9 @@ import { seedAuditTypes } from "./seeds/seed-audit-types";
 // Phase 4.a Infra — Dynamic Menu Management
 import { seedMenu } from "./seeds/seed-menu";
 
+// Phase 4.a — Staff WRI
+import { seedJobDesks } from "./seeds/seed-job-desks";
+
 async function main() {
   console.log("🌱 Starting seeding process...\n");
 
@@ -68,6 +71,10 @@ async function main() {
     // Phase 4.a Infra — Dynamic Menu Management (no FK dependencies)
     console.log("\n--- Phase 4.a Infra: Menu Management ---");
     await seedMenu(prisma);
+
+    // Phase 4.a — Staff WRI (depends on: job desks)
+    console.log("\n--- Phase 4.a: Staff WRI Reference Data ---");
+    await seedJobDesks(prisma);
 
     console.log("\n✅ All seeding completed successfully.");
   } catch (error) {

--- a/prisma/seeds/data/job-desks.csv
+++ b/prisma/seeds/data/job-desks.csv
@@ -1,0 +1,9 @@
+code,name
+MEL,MEL
+PROJECT_LEAD,Project Lead
+AGRONOMIST,Agronomist
+HCV,HCV
+HSE,HSE
+DISTRICT_COORDINATOR,District Coordinator
+BUSDEV,Busdev
+GEDSI,GEDSI

--- a/prisma/seeds/data/menu.csv
+++ b/prisma/seeds/data/menu.csv
@@ -14,8 +14,9 @@ md-farmers,master-data,Data Petani,/admin/master-data/farmers,User,22,true,true,
 md-parcels,master-data,Data Lahan,/admin/master-data/parcels,MapPin,23,true,true,all,all,all,all
 md-regions,master-data,Region / Wilayah,/admin/settings/regions,Globe,24,true,true,admin,all,all,all
 md-training,master-data,Training,/admin/master-data/training,GraduationCap,25,true,true,admin|operator,all,all,all
-md-bmp,master-data,Best Management Practices,/admin/master-data/bmp,BookMarked,26,true,true,admin|operator,all,all,all
-md-reg-ag,master-data,Regenerative Agriculture,/admin/master-data/reg-ag,Flower2,27,true,true,admin|operator,all,all,all
+md-staff,master-data,Staff WRI,/admin/master-data/staff,UserCheck,26,true,true,admin|operator,all,all,all
+md-bmp,master-data,Best Management Practices,/admin/master-data/bmp,BookMarked,27,true,true,admin|operator,all,all,all
+md-reg-ag,master-data,Regenerative Agriculture,/admin/master-data/reg-ag,Flower2,28,true,true,admin|operator,all,all,all
 cms,,CMS,#,MonitorIcon,30,true,true,admin,all,all,all
 cms-news,cms,Berita & Pengumuman,/admin/cms/news,FileText,31,true,true,all,all,all,all
 cms-knowledge,cms,Knowledge Management,/admin/cms/knowledge,BookOpen,32,true,true,all,all,all,all

--- a/prisma/seeds/seed-job-desks.ts
+++ b/prisma/seeds/seed-job-desks.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from "@prisma/client";
+import fs from "fs";
+import path from "path";
+import Papa from "papaparse";
+
+interface JobDeskCsvRow {
+  code: string;
+  name: string;
+}
+
+export async function seedJobDesks(prisma: PrismaClient) {
+  console.log("Seeding job desks...");
+
+  const filePath = path.resolve(__dirname, "data/job-desks.csv");
+  const { data } = Papa.parse<JobDeskCsvRow>(
+    fs.readFileSync(filePath, "utf8"),
+    { header: true, skipEmptyLines: true }
+  );
+
+  for (const row of data) {
+    await prisma.jobDesk.upsert({
+      where: { code: row.code },
+      update: { name: row.name },
+      create: { code: row.code, name: row.name },
+    });
+  }
+
+  console.log(`Seeded ${data.length} job desks.`);
+}

--- a/src/app/(admin)/admin/master-data/staff/[id]/page.tsx
+++ b/src/app/(admin)/admin/master-data/staff/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { getStaffById } from "@/server/actions/staff";
+import { notFound } from "next/navigation";
+import { StaffDetailClient } from "./staff-detail-client";
+
+export const metadata = { title: "Detail Staff WRI" };
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function StaffDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const result = await getStaffById(id);
+
+  if (!result.success || !result.data) {
+    notFound();
+  }
+
+  return (
+    <div className="p-6">
+      <StaffDetailClient staff={result.data} />
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/master-data/staff/[id]/staff-detail-client.tsx
+++ b/src/app/(admin)/admin/master-data/staff/[id]/staff-detail-client.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft, Mail, Briefcase, UserCheck, Users, MapPin, Building2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Table, TableBody, TableCell,
+  TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import type { StaffDetail } from "@/server/actions/staff";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface StaffDetailClientProps {
+  staff: StaffDetail;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function StaffDetailClient({ staff }: StaffDetailClientProps) {
+  const router = useRouter();
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      {/* Page Header */}
+      <div className="flex items-start gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
+          onClick={() => router.push("/admin/master-data/staff")}
+          title="Kembali ke Daftar Staff"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Detail Staff WRI</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {staff.staffCode} &bull; {staff.jobDesk.name}
+          </p>
+        </div>
+      </div>
+
+      {/* Section 1: Profil */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <UserCheck className="h-4 w-4 text-muted-foreground" />
+            Profil Staff
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4 text-sm">
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Kode Staff
+              </dt>
+              <dd className="font-mono font-medium">{staff.staffCode}</dd>
+            </div>
+
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Nama
+              </dt>
+              <dd className="font-medium">{staff.name}</dd>
+            </div>
+
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                <Briefcase className="h-3 w-3" />
+                Job Desk
+              </dt>
+              <dd>
+                <Badge variant="secondary">{staff.jobDesk.name}</Badge>
+              </dd>
+            </div>
+
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                <Mail className="h-3 w-3" />
+                Email WRI
+              </dt>
+              <dd>
+                {staff.emailWri ? (
+                  <a
+                    href={`mailto:${staff.emailWri}`}
+                    className="text-primary hover:underline"
+                  >
+                    {staff.emailWri}
+                  </a>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </dd>
+            </div>
+
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                <Users className="h-3 w-3" />
+                Line Manager
+              </dt>
+              <dd>
+                {staff.lineManager ? (
+                  <button
+                    onClick={() =>
+                      router.push(`/admin/master-data/staff/${staff.lineManager!.id}`)
+                    }
+                    className="text-primary hover:underline text-left"
+                  >
+                    {staff.lineManager.name}
+                    <span className="ml-2 text-xs font-mono text-muted-foreground">
+                      {staff.lineManager.staffCode}
+                    </span>
+                  </button>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </dd>
+            </div>
+
+            {staff.directReports.length > 0 && (
+              <div className="space-y-1 sm:col-span-2">
+                <dt className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Direct Reports ({staff.directReports.length})
+                </dt>
+                <dd className="flex flex-wrap gap-1.5">
+                  {staff.directReports.map((r) => (
+                    <button
+                      key={r.id}
+                      onClick={() =>
+                        router.push(`/admin/master-data/staff/${r.id}`)
+                      }
+                      className="inline-flex items-center gap-1"
+                    >
+                      <Badge variant="outline" className="hover:bg-accent cursor-pointer">
+                        {r.name}
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          · {r.jobDesk.name}
+                        </span>
+                      </Badge>
+                    </button>
+                  ))}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </CardContent>
+      </Card>
+
+      {/* Section 2: Distrik Penugasan */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Building2 className="h-4 w-4 text-muted-foreground" />
+            Distrik Penugasan
+          </CardTitle>
+          <CardDescription>
+            Kabupaten/kota yang menjadi area kerja staff ini. Kosong = semua distrik.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {staff.districts.length === 0 ? (
+            <div className="flex items-center gap-2 h-16 px-6 text-sm">
+              <Badge variant="secondary">Semua Distrik</Badge>
+              <span className="text-muted-foreground">
+                — staff ini bertugas di seluruh distrik
+              </span>
+            </div>
+          ) : (
+            <div className="rounded-b-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/70 hover:bg-muted/70 border-b-2 border-border">
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground w-10">
+                      No
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Nama Distrik
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Provinsi
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {staff.districts.map((sd, i) => (
+                    <TableRow key={sd.id}>
+                      <TableCell className="text-sm tabular-nums text-muted-foreground">
+                        {i + 1}
+                      </TableCell>
+                      <TableCell className="text-sm font-medium">
+                        {sd.district.name}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {sd.district.province.name}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Section 3: Kelompok Tani Penugasan */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            Kelompok Tani Penugasan
+          </CardTitle>
+          <CardDescription>
+            Kelompok tani yang menjadi tanggung jawab staff ini. Kosong = semua kelompok tani.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {staff.farmerGroups.length === 0 ? (
+            <div className="flex items-center gap-2 h-16 px-6 text-sm">
+              <Badge variant="secondary">Semua Kelompok Tani</Badge>
+              <span className="text-muted-foreground">
+                — staff ini bertugas di seluruh kelompok tani
+              </span>
+            </div>
+          ) : (
+            <div className="rounded-b-lg overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/70 hover:bg-muted/70 border-b-2 border-border">
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground w-10">
+                      No
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Nama KT
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Kode
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Distrik
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {staff.farmerGroups.map((sfg, i) => (
+                    <TableRow key={sfg.id}>
+                      <TableCell className="text-sm tabular-nums text-muted-foreground">
+                        {i + 1}
+                      </TableCell>
+                      <TableCell className="text-sm font-medium">
+                        {sfg.farmerGroup.name}
+                      </TableCell>
+                      <TableCell className="text-sm font-mono text-muted-foreground">
+                        {sfg.farmerGroup.code || "—"}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {sfg.farmerGroup.district.name}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/master-data/staff/page.tsx
+++ b/src/app/(admin)/admin/master-data/staff/page.tsx
@@ -1,0 +1,33 @@
+import {
+  getStaff,
+  getJobDesksForDropdown,
+  getStaffForDropdown,
+} from "@/server/actions/staff";
+import { getDistrictsForDropdown } from "@/server/actions/farmer-group";
+import { getFarmerGroupsForDropdown } from "@/server/actions/training";
+import { StaffListClient } from "./staff-list-client";
+
+export const metadata = { title: "Master Data Staff WRI" };
+
+export default async function StaffPage() {
+  const [staffResult, jobDesksResult, districtsResult, farmerGroupsResult, staffDropdownResult] =
+    await Promise.all([
+      getStaff(),
+      getJobDesksForDropdown(),
+      getDistrictsForDropdown(),
+      getFarmerGroupsForDropdown(),
+      getStaffForDropdown(),
+    ]);
+
+  return (
+    <div className="p-6">
+      <StaffListClient
+        initialStaff={staffResult.success ? (staffResult.data ?? []) : []}
+        jobDesks={jobDesksResult.success ? (jobDesksResult.data ?? []) : []}
+        districts={districtsResult.success ? (districtsResult.data ?? []) : []}
+        farmerGroups={farmerGroupsResult.success ? (farmerGroupsResult.data ?? []) : []}
+        staffDropdown={staffDropdownResult.success ? (staffDropdownResult.data ?? []) : []}
+      />
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/master-data/staff/staff-form-modal.tsx
+++ b/src/app/(admin)/admin/master-data/staff/staff-form-modal.tsx
@@ -1,0 +1,630 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { staffSchema, type StaffFormValues } from "@/validations/staff.schema";
+import {
+  createStaff,
+  updateStaff,
+  type StaffDetail,
+  type JobDeskDropdownItem,
+  type StaffDropdownItem,
+} from "@/server/actions/staff";
+import type { DistrictDropdownItem } from "@/server/actions/farmer-group";
+import type { FarmerGroupDropdownItem } from "@/server/actions/training";
+import { toast } from "sonner";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// ─── JobDesk Combobox ─────────────────────────────────────────────────────────
+
+function JobDeskCombobox({
+  value,
+  onChange,
+  jobDesks,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  jobDesks: JobDeskDropdownItem[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const label = jobDesks.find((j) => j.id === value)?.name ?? "Pilih job desk";
+
+  const filtered = useMemo(() => {
+    if (!search) return jobDesks;
+    return jobDesks.filter((j) =>
+      j.name.toLowerCase().includes(search.toLowerCase())
+    );
+  }, [jobDesks, search]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            className={cn("w-full justify-between font-normal", !value && "text-muted-foreground")}
+          />
+        }
+      >
+        {label}
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </PopoverTrigger>
+      <PopoverContent className="w-[300px] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Cari job desk..."
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {filtered.length === 0 ? (
+              <CommandEmpty>Job desk tidak ditemukan.</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {filtered.map((j) => (
+                  <CommandItem
+                    key={j.id}
+                    value={j.id}
+                    onSelect={() => {
+                      onChange(j.id);
+                      setSearch("");
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn("mr-2 h-4 w-4", value === j.id ? "opacity-100" : "opacity-0")}
+                    />
+                    {j.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface StaffFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  staff?: StaffDetail | null;
+  jobDesks: JobDeskDropdownItem[];
+  districts: DistrictDropdownItem[];
+  farmerGroups: FarmerGroupDropdownItem[];
+  staffDropdown: StaffDropdownItem[];
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function StaffFormModal({
+  isOpen,
+  onClose,
+  staff,
+  jobDesks,
+  districts,
+  farmerGroups,
+  staffDropdown,
+}: StaffFormModalProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [openLineManager, setOpenLineManager] = useState(false);
+  const isEditing = !!staff;
+
+  // ─── Form ──────────────────────────────────────────────────────────────
+
+  const form = useForm<StaffFormValues>({
+    resolver: zodResolver(staffSchema as any),
+    defaultValues: {
+      staffCode: staff?.staffCode ?? "",
+      name: staff?.name ?? "",
+      jobDeskId: staff?.jobDeskId ?? "",
+      emailWri: staff?.emailWri ?? "",
+      lineManagerId: staff?.lineManagerId ?? "",
+      districtIds: [],
+      farmerGroupIds: [],
+    },
+  });
+
+  // ─── District multi-select state ────────────────────────────────────────
+
+  const [selectedDistrictIds, setSelectedDistrictIds] = useState<Set<string>>(
+    () => new Set(staff?.districts?.map((sd) => sd.district.id) ?? [])
+  );
+  const [districtSearch, setDistrictSearch] = useState("");
+
+  const filteredDistricts = useMemo(() => {
+    const q = districtSearch.toLowerCase();
+    if (!q) return districts;
+    return districts.filter(
+      (d) =>
+        d.name.toLowerCase().includes(q) ||
+        d.province.name.toLowerCase().includes(q)
+    );
+  }, [districts, districtSearch]);
+
+  function toggleDistrict(id: string) {
+    setSelectedDistrictIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAllDistricts() {
+    setSelectedDistrictIds(new Set(districts.map((d) => d.id)));
+  }
+
+  // ─── FarmerGroup multi-select state ─────────────────────────────────────
+
+  const [selectedFarmerGroupIds, setSelectedFarmerGroupIds] = useState<Set<string>>(
+    () => new Set(staff?.farmerGroups?.map((sfg) => sfg.farmerGroup.id) ?? [])
+  );
+  const [fgSearch, setFgSearch] = useState("");
+
+  const filteredFarmerGroups = useMemo(() => {
+    const q = fgSearch.toLowerCase();
+    if (!q) return farmerGroups;
+    return farmerGroups.filter(
+      (g) =>
+        g.name.toLowerCase().includes(q) ||
+        (g.code?.toLowerCase().includes(q) ?? false)
+    );
+  }, [farmerGroups, fgSearch]);
+
+  function toggleFarmerGroup(id: string) {
+    setSelectedFarmerGroupIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAllFarmerGroupsByDistrict(districtId: string) {
+    const ids = farmerGroups
+      .filter((g) => g.district.name === districts.find((d) => d.id === districtId)?.name)
+      .map((g) => g.id);
+    setSelectedFarmerGroupIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+  }
+
+  // ─── Submit ────────────────────────────────────────────────────────────
+
+  async function onSubmit(data: StaffFormValues) {
+    setIsPending(true);
+    const payload: StaffFormValues = {
+      ...data,
+      districtIds: Array.from(selectedDistrictIds),
+      farmerGroupIds: Array.from(selectedFarmerGroupIds),
+    };
+
+    const result = isEditing
+      ? await updateStaff(staff!.id, payload)
+      : await createStaff(payload);
+    setIsPending(false);
+
+    if (result.success) {
+      toast.success(
+        isEditing ? "Data staff berhasil diperbarui." : "Staff berhasil ditambahkan."
+      );
+      onClose();
+    } else {
+      toast.error(result.error);
+    }
+  }
+
+  // ─── Render ────────────────────────────────────────────────────────────
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[640px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? "Edit Staff WRI" : "Tambah Staff WRI"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5 pt-2">
+
+            {/* Row: Kode + Nama */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="staffCode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Kode Staff *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="SH-001" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nama *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nama lengkap" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Job Desk */}
+            <FormField
+              control={form.control}
+              name="jobDeskId"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Job Desk *</FormLabel>
+                  <JobDeskCombobox
+                    value={field.value}
+                    onChange={(val) => form.setValue("jobDeskId", val)}
+                    jobDesks={jobDesks}
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Row: Email + Line Manager */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="emailWri"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email WRI</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="nama@wri.org"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="lineManagerId"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>Line Manager</FormLabel>
+                    <Popover open={openLineManager} onOpenChange={setOpenLineManager}>
+                      <PopoverTrigger
+                        render={
+                          <Button
+                            variant="outline"
+                            role="combobox"
+                            className={cn(
+                              "w-full justify-between font-normal",
+                              !field.value && "text-muted-foreground"
+                            )}
+                          />
+                        }
+                      >
+                        {field.value
+                          ? (staffDropdown.find((s) => s.id === field.value)?.name ?? "Pilih line manager")
+                          : "Pilih line manager"}
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </PopoverTrigger>
+                      <PopoverContent className="w-[260px] p-0" align="start">
+                        <Command>
+                          <CommandInput placeholder="Cari staff..." />
+                          <CommandList>
+                            <CommandEmpty>Staff tidak ditemukan.</CommandEmpty>
+                            <CommandGroup>
+                              <CommandItem
+                                value="none"
+                                onSelect={() => {
+                                  form.setValue("lineManagerId", "");
+                                  setOpenLineManager(false);
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    !field.value ? "opacity-100" : "opacity-0"
+                                  )}
+                                />
+                                <span className="text-muted-foreground">— Tidak ada —</span>
+                              </CommandItem>
+                              {staffDropdown
+                                .filter((s) => !isEditing || s.id !== staff?.id)
+                                .map((s) => (
+                                  <CommandItem
+                                    key={s.id}
+                                    value={`${s.name} ${s.staffCode}`}
+                                    onSelect={() => {
+                                      form.setValue("lineManagerId", s.id);
+                                      setOpenLineManager(false);
+                                    }}
+                                  >
+                                    <Check
+                                      className={cn(
+                                        "mr-2 h-4 w-4",
+                                        field.value === s.id ? "opacity-100" : "opacity-0"
+                                      )}
+                                    />
+                                    <span>{s.name}</span>
+                                    <span className="ml-2 text-xs font-mono text-muted-foreground">
+                                      {s.staffCode}
+                                    </span>
+                                  </CommandItem>
+                                ))}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Distrik Assignment */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">
+                  Distrik Penugasan
+                  <span className="ml-2 text-xs text-muted-foreground font-normal">
+                    ({selectedDistrictIds.size === 0 ? "kosong = semua distrik" : `${selectedDistrictIds.size} dipilih`})
+                  </span>
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={selectAllDistricts}
+                  >
+                    Pilih Semua
+                  </Button>
+                  {selectedDistrictIds.size > 0 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 text-xs text-muted-foreground"
+                      onClick={() => setSelectedDistrictIds(new Set())}
+                    >
+                      Reset
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <div className="relative">
+                <Input
+                  placeholder="Cari distrik..."
+                  value={districtSearch}
+                  onChange={(e) => setDistrictSearch(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              <ScrollArea className="h-36 rounded-md border">
+                <div className="p-1">
+                  {filteredDistricts.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-4">
+                      Distrik tidak ditemukan.
+                    </p>
+                  ) : (
+                    filteredDistricts.map((d) => {
+                      const checked = selectedDistrictIds.has(d.id);
+                      return (
+                        <button
+                          key={d.id}
+                          type="button"
+                          onClick={() => toggleDistrict(d.id)}
+                          className={`w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent ${checked ? "bg-primary/10" : ""}`}
+                        >
+                          <span
+                            className={`h-4 w-4 shrink-0 rounded border flex items-center justify-center ${checked ? "bg-primary border-primary text-primary-foreground" : "border-border"}`}
+                          >
+                            {checked && <Check className="h-3 w-3" />}
+                          </span>
+                          <span className="flex-1 min-w-0">
+                            <span className="font-medium truncate block">{d.name}</span>
+                            <span className="text-xs text-muted-foreground">{d.province.name}</span>
+                          </span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+              {selectedDistrictIds.size > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {Array.from(selectedDistrictIds).map((id) => {
+                    const d = districts.find((x) => x.id === id);
+                    if (!d) return null;
+                    return (
+                      <Badge key={id} variant="secondary" className="gap-1 pr-1">
+                        {d.name}
+                        <button
+                          type="button"
+                          onClick={() => toggleDistrict(id)}
+                          className="rounded hover:bg-muted"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Kelompok Tani Assignment */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">
+                  Kelompok Tani Penugasan
+                  <span className="ml-2 text-xs text-muted-foreground font-normal">
+                    ({selectedFarmerGroupIds.size === 0 ? "kosong = semua KT" : `${selectedFarmerGroupIds.size} dipilih`})
+                  </span>
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() =>
+                      setSelectedFarmerGroupIds(new Set(farmerGroups.map((g) => g.id)))
+                    }
+                  >
+                    Pilih Semua
+                  </Button>
+                  {selectedFarmerGroupIds.size > 0 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 text-xs text-muted-foreground"
+                      onClick={() => setSelectedFarmerGroupIds(new Set())}
+                    >
+                      Reset
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <Input
+                placeholder="Cari kelompok tani..."
+                value={fgSearch}
+                onChange={(e) => setFgSearch(e.target.value)}
+                className="h-8 text-sm"
+              />
+              <ScrollArea className="h-36 rounded-md border">
+                <div className="p-1">
+                  {filteredFarmerGroups.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-4">
+                      Kelompok tani tidak ditemukan.
+                    </p>
+                  ) : (
+                    filteredFarmerGroups.map((g) => {
+                      const checked = selectedFarmerGroupIds.has(g.id);
+                      return (
+                        <button
+                          key={g.id}
+                          type="button"
+                          onClick={() => toggleFarmerGroup(g.id)}
+                          className={`w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent ${checked ? "bg-primary/10" : ""}`}
+                        >
+                          <span
+                            className={`h-4 w-4 shrink-0 rounded border flex items-center justify-center ${checked ? "bg-primary border-primary text-primary-foreground" : "border-border"}`}
+                          >
+                            {checked && <Check className="h-3 w-3" />}
+                          </span>
+                          <span className="flex-1 min-w-0">
+                            <span className="font-medium truncate block">{g.name}</span>
+                            <span className="text-xs font-mono text-muted-foreground">
+                              {g.code ?? g.district.name}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+              {selectedFarmerGroupIds.size > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {Array.from(selectedFarmerGroupIds).map((id) => {
+                    const g = farmerGroups.find((x) => x.id === id);
+                    if (!g) return null;
+                    return (
+                      <Badge key={id} variant="secondary" className="gap-1 pr-1">
+                        {g.name}
+                        <button
+                          type="button"
+                          onClick={() => toggleFarmerGroup(id)}
+                          className="rounded hover:bg-muted"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter className="pt-2">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+                Batal
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Menyimpan..." : "Simpan"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/admin/master-data/staff/staff-list-client.tsx
+++ b/src/app/(admin)/admin/master-data/staff/staff-list-client.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Eye, Edit2, Trash2, Plus, Check, ChevronsUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { DataTable, DataTableColumn } from "@/components/shared/data-table";
+import { DeleteDialog } from "@/components/shared/delete-dialog";
+import {
+  deleteStaff,
+  getStaffById,
+  type StaffRow,
+  type StaffDetail,
+  type JobDeskDropdownItem,
+  type StaffDropdownItem,
+} from "@/server/actions/staff";
+import type { DistrictDropdownItem } from "@/server/actions/farmer-group";
+import type { FarmerGroupDropdownItem } from "@/server/actions/training";
+import { StaffFormModal } from "./staff-form-modal";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface StaffListClientProps {
+  initialStaff: StaffRow[];
+  jobDesks: JobDeskDropdownItem[];
+  districts: DistrictDropdownItem[];
+  farmerGroups: FarmerGroupDropdownItem[];
+  staffDropdown: StaffDropdownItem[];
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function StaffListClient({
+  initialStaff,
+  jobDesks,
+  districts,
+  farmerGroups,
+  staffDropdown,
+}: StaffListClientProps) {
+  const router = useRouter();
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editStaff, setEditStaff] = useState<StaffDetail | null>(null);
+  const [filterJobDeskId, setFilterJobDeskId] = useState<string>("all");
+  const [jobDeskOpen, setJobDeskOpen] = useState(false);
+
+  // ─── Open edit modal — fetch detail first ────────────────────────────────
+
+  async function handleOpenEdit(row: StaffRow) {
+    const result = await getStaffById(row.id);
+    if (result.success && result.data) {
+      setEditStaff(result.data);
+      setModalOpen(true);
+    } else {
+      toast.error("Gagal memuat data staff.");
+    }
+  }
+
+  // ─── Filter ─────────────────────────────────────────────────────────────
+
+  const filteredStaff = useMemo(() => {
+    if (filterJobDeskId === "all") return initialStaff;
+    return initialStaff.filter((s) => s.jobDeskId === filterJobDeskId);
+  }, [initialStaff, filterJobDeskId]);
+
+  const selectedJobDeskLabel =
+    filterJobDeskId === "all"
+      ? "Semua Job Desk"
+      : jobDesks.find((j) => j.id === filterJobDeskId)?.name ?? "Semua Job Desk";
+
+  // ─── Columns ────────────────────────────────────────────────────────────
+
+  const columns: DataTableColumn<StaffRow>[] = [
+    {
+      key: "staffCode",
+      label: "Kode Staff",
+      cellClassName: "text-sm font-mono text-muted-foreground",
+    },
+    {
+      key: "name",
+      label: "Nama",
+      cellClassName: "text-sm font-medium",
+    },
+    {
+      key: "jobDesk",
+      label: "Job Desk",
+      render: (row) => (
+        <Badge variant="secondary">{row.jobDesk.name}</Badge>
+      ),
+    },
+    {
+      key: "emailWri",
+      label: "Email WRI",
+      render: (row) => (
+        <span className="text-sm text-muted-foreground">
+          {row.emailWri || "—"}
+        </span>
+      ),
+    },
+    {
+      key: "lineManager",
+      label: "Line Manager",
+      render: (row) =>
+        row.lineManager ? (
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm">{row.lineManager.name}</span>
+            <span className="text-xs font-mono text-muted-foreground">
+              {row.lineManager.staffCode}
+            </span>
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">—</span>
+        ),
+    },
+    {
+      key: "_count",
+      label: "Penugasan",
+      sortable: false,
+      render: (row) => (
+        <div className="flex items-center gap-1.5">
+          <Badge variant="outline" className="tabular-nums text-xs">
+            {row._count.districts === 0 ? "Semua distrik" : `${row._count.districts} distrik`}
+          </Badge>
+          <Badge variant="outline" className="tabular-nums text-xs">
+            {row._count.farmerGroups === 0 ? "Semua KT" : `${row._count.farmerGroups} KT`}
+          </Badge>
+        </div>
+      ),
+    },
+  ];
+
+  // ─── Handlers ───────────────────────────────────────────────────────────
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    const result = await deleteStaff(deleteId);
+    if (result.success) {
+      toast.success("Data staff berhasil dihapus.");
+      setDeleteId(null);
+      router.refresh();
+    } else {
+      toast.error(result.error);
+    }
+  };
+
+  // ─── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Staff WRI</h1>
+          <p className="text-muted-foreground">
+            Daftar staff WRI beserta job desk dan area penugasan.
+          </p>
+        </div>
+        <Button
+          onClick={() => {
+            setEditStaff(null);
+            setModalOpen(true);
+          }}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Tambah Staff
+        </Button>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={filteredStaff}
+        rowKey={(r) => r.id}
+        searchPlaceholder="Cari nama, kode, atau email..."
+        searchFn={(row, q) =>
+          row.name.toLowerCase().includes(q) ||
+          row.staffCode.toLowerCase().includes(q) ||
+          (row.emailWri?.toLowerCase().includes(q) ?? false) ||
+          row.jobDesk.name.toLowerCase().includes(q)
+        }
+        emptyMessage="Belum ada data staff WRI."
+        toolbarLeft={
+          <Popover open={jobDeskOpen} onOpenChange={setJobDeskOpen}>
+            <PopoverTrigger
+              render={
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={jobDeskOpen}
+                  className="w-[200px] justify-between h-9"
+                />
+              }
+            >
+              {selectedJobDeskLabel}
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </PopoverTrigger>
+            <PopoverContent className="w-[220px] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Cari job desk..." />
+                <CommandList>
+                  <CommandEmpty>Job desk tidak ditemukan.</CommandEmpty>
+                  <CommandGroup>
+                    <CommandItem
+                      value="all"
+                      onSelect={() => {
+                        setFilterJobDeskId("all");
+                        setJobDeskOpen(false);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          filterJobDeskId === "all" ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      Semua Job Desk
+                    </CommandItem>
+                    {jobDesks.map((j) => (
+                      <CommandItem
+                        key={j.id}
+                        value={j.name}
+                        onSelect={() => {
+                          setFilterJobDeskId(j.id);
+                          setJobDeskOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            filterJobDeskId === j.id ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        {j.name}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        }
+        renderActions={(row) => (
+          <div className="inline-flex items-center gap-1">
+            <button
+              title="Lihat Detail"
+              className="h-8 w-8 inline-flex items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+              onClick={() => router.push(`/admin/master-data/staff/${row.id}`)}
+            >
+              <Eye className="h-4 w-4" />
+              <span className="sr-only">Lihat</span>
+            </button>
+            <button
+              title="Edit"
+              className="h-8 w-8 inline-flex items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+              onClick={() => handleOpenEdit(row)}
+            >
+              <Edit2 className="h-4 w-4" />
+              <span className="sr-only">Edit</span>
+            </button>
+            <button
+              title="Hapus"
+              className="h-8 w-8 inline-flex items-center justify-center rounded-md text-red-600 transition-colors hover:bg-red-100 hover:text-red-700 dark:hover:bg-red-950"
+              onClick={() => setDeleteId(row.id)}
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="sr-only">Hapus</span>
+            </button>
+          </div>
+        )}
+      />
+
+      <DeleteDialog
+        open={!!deleteId}
+        onClose={() => setDeleteId(null)}
+        onConfirm={handleDelete}
+        title="Hapus Staff"
+        description="Apakah Anda yakin ingin menghapus data staff ini? Staff yang masih menjadi line manager tidak dapat dihapus."
+      />
+
+      {modalOpen && (
+        <StaffFormModal
+          isOpen={modalOpen}
+          onClose={() => {
+            setModalOpen(false);
+            setEditStaff(null);
+            router.refresh();
+          }}
+          staff={editStaff}
+          jobDesks={jobDesks}
+          districts={districts}
+          farmerGroups={farmerGroups}
+          staffDropdown={staffDropdown}
+        />
+      )}    </div>
+  );
+}

--- a/src/server/actions/staff.ts
+++ b/src/server/actions/staff.ts
@@ -1,0 +1,300 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/types/action-result";
+import type { StaffFormValues } from "@/validations/staff.schema";
+
+const REVALIDATE_PATH = "/admin/master-data/staff";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface StaffRow {
+  id: string;
+  staffCode: string;
+  name: string;
+  emailWri: string | null;
+  jobDeskId: string;
+  jobDesk: { id: string; code: string; name: string };
+  lineManagerId: string | null;
+  lineManager: { id: string; name: string; staffCode: string } | null;
+  _count: {
+    districts: number;
+    farmerGroups: number;
+  };
+}
+
+export interface StaffDetail extends StaffRow {
+  districts: {
+    id: string;
+    district: {
+      id: string;
+      name: string;
+      province: { name: string };
+    };
+  }[];
+  farmerGroups: {
+    id: string;
+    farmerGroup: {
+      id: string;
+      name: string;
+      code: string | null;
+      district: { name: string };
+    };
+  }[];
+  directReports: { id: string; name: string; staffCode: string; jobDesk: { name: string } }[];
+}
+
+export interface JobDeskDropdownItem {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export interface StaffDropdownItem {
+  id: string;
+  staffCode: string;
+  name: string;
+}
+
+// ─── Read ────────────────────────────────────────────────────────────────────
+
+export async function getStaff(): Promise<ActionResult<StaffRow[]>> {
+  try {
+    const staff = await prisma.staff.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        jobDesk: { select: { id: true, code: true, name: true } },
+        lineManager: { select: { id: true, name: true, staffCode: true } },
+        _count: { select: { districts: true, farmerGroups: true } },
+      },
+    });
+    return { success: true, data: staff as unknown as StaffRow[] };
+  } catch (error) {
+    console.error("Failed to fetch staff:", error);
+    return { success: false, error: "Gagal memuat data staff." };
+  }
+}
+
+export async function getStaffById(
+  id: string
+): Promise<ActionResult<StaffDetail>> {
+  try {
+    const staff = await prisma.staff.findUnique({
+      where: { id },
+      include: {
+        jobDesk: { select: { id: true, code: true, name: true } },
+        lineManager: { select: { id: true, name: true, staffCode: true } },
+        districts: {
+          include: {
+            district: {
+              select: {
+                id: true,
+                name: true,
+                province: { select: { name: true } },
+              },
+            },
+          },
+          orderBy: { district: { name: "asc" } },
+        },
+        farmerGroups: {
+          include: {
+            farmerGroup: {
+              select: {
+                id: true,
+                name: true,
+                code: true,
+                district: { select: { name: true } },
+              },
+            },
+          },
+          orderBy: { farmerGroup: { name: "asc" } },
+        },
+        directReports: {
+          select: {
+            id: true,
+            name: true,
+            staffCode: true,
+            jobDesk: { select: { name: true } },
+          },
+          orderBy: { name: "asc" },
+        },
+        _count: { select: { districts: true, farmerGroups: true } },
+      },
+    });
+
+    if (!staff) {
+      return { success: false, error: "Staff tidak ditemukan." };
+    }
+
+    return { success: true, data: staff as unknown as StaffDetail };
+  } catch (error) {
+    console.error("Failed to fetch staff by id:", error);
+    return { success: false, error: "Gagal memuat detail staff." };
+  }
+}
+
+export async function getJobDesksForDropdown(): Promise<
+  ActionResult<JobDeskDropdownItem[]>
+> {
+  try {
+    const jobDesks = await prisma.jobDesk.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, code: true, name: true },
+    });
+    return { success: true, data: jobDesks };
+  } catch (error) {
+    console.error("Failed to fetch job desks:", error);
+    return { success: false, error: "Gagal memuat data job desk." };
+  }
+}
+
+export async function getStaffForDropdown(): Promise<
+  ActionResult<StaffDropdownItem[]>
+> {
+  try {
+    const staff = await prisma.staff.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, staffCode: true, name: true },
+    });
+    return { success: true, data: staff };
+  } catch (error) {
+    console.error("Failed to fetch staff for dropdown:", error);
+    return { success: false, error: "Gagal memuat data staff." };
+  }
+}
+
+// ─── Create ──────────────────────────────────────────────────────────────────
+
+export async function createStaff(data: StaffFormValues): Promise<ActionResult> {
+  try {
+    const { staffSchema } = await import("@/validations/staff.schema");
+    const validated = staffSchema.parse(data);
+
+    // Check unique staffCode
+    const existing = await prisma.staff.findUnique({
+      where: { staffCode: validated.staffCode },
+    });
+    if (existing) {
+      return { success: false, error: "Kode staff sudah digunakan." };
+    }
+
+    await prisma.staff.create({
+      data: {
+        staffCode: validated.staffCode,
+        name: validated.name,
+        jobDeskId: validated.jobDeskId,
+        emailWri: validated.emailWri || null,
+        lineManagerId: validated.lineManagerId || null,
+        createdBy: null,
+        modifiedBy: null,
+        districts: {
+          create: validated.districtIds.map((districtId) => ({ districtId })),
+        },
+        farmerGroups: {
+          create: validated.farmerGroupIds.map((farmerGroupId) => ({
+            farmerGroupId,
+          })),
+        },
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to create staff:", error);
+    const message =
+      error instanceof Error ? error.message : "Gagal membuat data staff.";
+    return { success: false, error: message };
+  }
+}
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+export async function updateStaff(
+  id: string,
+  data: StaffFormValues
+): Promise<ActionResult> {
+  try {
+    const { staffSchema } = await import("@/validations/staff.schema");
+    const validated = staffSchema.parse(data);
+
+    // Check unique staffCode (exclude self)
+    const existing = await prisma.staff.findUnique({
+      where: { staffCode: validated.staffCode },
+    });
+    if (existing && existing.id !== id) {
+      return { success: false, error: "Kode staff sudah digunakan." };
+    }
+
+    // Prevent self-referential line manager
+    if (validated.lineManagerId === id) {
+      return {
+        success: false,
+        error: "Staff tidak bisa menjadi line manager dirinya sendiri.",
+      };
+    }
+
+    await prisma.$transaction([
+      // Delete existing assignments
+      prisma.staffDistrict.deleteMany({ where: { staffId: id } }),
+      prisma.staffFarmerGroup.deleteMany({ where: { staffId: id } }),
+      // Update staff + re-create assignments
+      prisma.staff.update({
+        where: { id },
+        data: {
+          staffCode: validated.staffCode,
+          name: validated.name,
+          jobDeskId: validated.jobDeskId,
+          emailWri: validated.emailWri || null,
+          lineManagerId: validated.lineManagerId || null,
+          modifiedBy: null,
+          districts: {
+            create: validated.districtIds.map((districtId) => ({ districtId })),
+          },
+          farmerGroups: {
+            create: validated.farmerGroupIds.map((farmerGroupId) => ({
+              farmerGroupId,
+            })),
+          },
+        },
+      }),
+    ]);
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to update staff:", error);
+    const message =
+      error instanceof Error ? error.message : "Gagal mengupdate data staff.";
+    return { success: false, error: message };
+  }
+}
+
+// ─── Delete ──────────────────────────────────────────────────────────────────
+
+export async function deleteStaff(id: string): Promise<ActionResult> {
+  try {
+    // Check if staff has direct reports
+    const directReportCount = await prisma.staff.count({
+      where: { lineManagerId: id },
+    });
+    if (directReportCount > 0) {
+      return {
+        success: false,
+        error: `Tidak dapat menghapus. Staff ini masih menjadi line manager dari ${directReportCount} staff lain.`,
+      };
+    }
+
+    // Cascade delete assignments (no DB cascade for these)
+    await prisma.staffDistrict.deleteMany({ where: { staffId: id } });
+    await prisma.staffFarmerGroup.deleteMany({ where: { staffId: id } });
+    await prisma.staff.delete({ where: { id } });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to delete staff:", error);
+    return { success: false, error: "Gagal menghapus data staff." };
+  }
+}

--- a/src/test/staff.test.ts
+++ b/src/test/staff.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { staffSchema } from "@/validations/staff.schema";
+
+describe("staffSchema", () => {
+  // ─── Valid data ─────────────────────────────────────────────────────────
+
+  it("accepts valid staff data", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Budi Santoso",
+      jobDeskId: "jd-001",
+    });
+    expect(result.staffCode).toBe("SH-001");
+    expect(result.name).toBe("Budi Santoso");
+    expect(result.jobDeskId).toBe("jd-001");
+  });
+
+  it("accepts data with all optional fields", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-002",
+      name: "Siti Rahayu",
+      jobDeskId: "jd-002",
+      emailWri: "siti@wri.org",
+      lineManagerId: "staff-abc",
+      districtIds: ["dist-1", "dist-2"],
+      farmerGroupIds: ["fg-1", "fg-2", "fg-3"],
+    });
+    expect(result.emailWri).toBe("siti@wri.org");
+    expect(result.lineManagerId).toBe("staff-abc");
+    expect(result.districtIds).toHaveLength(2);
+    expect(result.farmerGroupIds).toHaveLength(3);
+  });
+
+  it("accepts data with optional id (edit mode)", () => {
+    const result = staffSchema.parse({
+      id: "staff-xyz",
+      staffCode: "SH-003",
+      name: "Ahmad Yani",
+      jobDeskId: "jd-003",
+    });
+    expect(result.id).toBe("staff-xyz");
+  });
+
+  it("defaults districtIds and farmerGroupIds to empty arrays", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-004",
+      name: "Test Staff",
+      jobDeskId: "jd-001",
+    });
+    expect(result.districtIds).toEqual([]);
+    expect(result.farmerGroupIds).toEqual([]);
+  });
+
+  // ─── Required field validation ──────────────────────────────────────────
+
+  it("rejects empty staffCode", () => {
+    expect(() =>
+      staffSchema.parse({ staffCode: "", name: "Test", jobDeskId: "jd-1" })
+    ).toThrow();
+  });
+
+  it("rejects name shorter than 2 characters", () => {
+    expect(() =>
+      staffSchema.parse({ staffCode: "SH-001", name: "A", jobDeskId: "jd-1" })
+    ).toThrow();
+  });
+
+  it("rejects empty jobDeskId", () => {
+    expect(() =>
+      staffSchema.parse({ staffCode: "SH-001", name: "Test Staff", jobDeskId: "" })
+    ).toThrow();
+  });
+
+  // ─── Email validation ───────────────────────────────────────────────────
+
+  it("rejects invalid email format", () => {
+    expect(() =>
+      staffSchema.parse({
+        staffCode: "SH-001",
+        name: "Test Staff",
+        jobDeskId: "jd-1",
+        emailWri: "not-an-email",
+      })
+    ).toThrow();
+  });
+
+  it("accepts empty email string", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Test Staff",
+      jobDeskId: "jd-1",
+      emailWri: "",
+    });
+    expect(result.emailWri).toBe("");
+  });
+
+  it("accepts valid WRI email", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Test Staff",
+      jobDeskId: "jd-1",
+      emailWri: "test@wri.org",
+    });
+    expect(result.emailWri).toBe("test@wri.org");
+  });
+
+  // ─── Optional fields ────────────────────────────────────────────────────
+
+  it("accepts null lineManagerId", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Test Staff",
+      jobDeskId: "jd-1",
+      lineManagerId: null,
+    });
+    expect(result.lineManagerId).toBeNull();
+  });
+
+  it("accepts empty lineManagerId string", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Test Staff",
+      jobDeskId: "jd-1",
+      lineManagerId: "",
+    });
+    expect(result.lineManagerId).toBe("");
+  });
+});
+
+// ─── Staff code format ────────────────────────────────────────────────────────
+
+describe("Staff code format validation", () => {
+  it("accepts SH-001 format", () => {
+    const result = staffSchema.parse({
+      staffCode: "SH-001",
+      name: "Test",
+      jobDeskId: "jd-1",
+    });
+    expect(result.staffCode).toBe("SH-001");
+  });
+
+  it("accepts any non-empty string as staff code", () => {
+    const result = staffSchema.parse({
+      staffCode: "WRI-DC-007",
+      name: "Test",
+      jobDeskId: "jd-1",
+    });
+    expect(result.staffCode).toBe("WRI-DC-007");
+  });
+});

--- a/src/validations/staff.schema.ts
+++ b/src/validations/staff.schema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const staffSchema = z.object({
+  id: z.string().optional(),
+  staffCode: z.string().min(1, "Kode staff wajib diisi"),
+  name: z.string().min(2, "Nama minimal 2 karakter"),
+  jobDeskId: z.string().min(1, "Job desk wajib dipilih"),
+  emailWri: z
+    .string()
+    .email("Format email tidak valid")
+    .optional()
+    .or(z.literal("")),
+  lineManagerId: z.string().optional().or(z.literal("")).nullable(),
+  // IDs of assigned districts
+  districtIds: z.array(z.string()).default([]),
+  // IDs of assigned farmer groups
+  farmerGroupIds: z.array(z.string()).default([]),
+});
+
+export type StaffFormValues = z.infer<typeof staffSchema>;


### PR DESCRIPTION
feat(#41): Master Data Staff WRI — List, Detail, CRUD, Job Desk, Penugasan

- Prisma schema: JobDesk, Staff (self-ref lineManagerId), StaffDistrict, StaffFarmerGroup (many-to-many District & FarmerGroup)
- Back-relations di geography.prisma, farmer-group.prisma, user.prisma
- Migration SQL manual: 4 tabel baru dengan FK constraints
- Seed: 8 job desks (MEL, Project Lead, Agronomist, HCV, HSE, District Coordinator, Busdev, GEDSI) + menu entry md-staff
- Zod schema: staffCode, name, jobDeskId required; emailWri, lineManagerId, districtIds[], farmerGroupIds[] optional
- Server actions: getStaff, getStaffById, createStaff, updateStaff, deleteStaff (guard direct reports), getJobDesksForDropdown, getStaffForDropdown
- List page: DataTable + filter Job Desk searchable combobox + search nama/kode/email + tombol Tambah Staff
- Form modal create/edit:
  - Job Desk: Popover+Command shouldFilter=false (fix base-ui Select compat)
  - Line Manager: searchable combobox, exclude self saat edit
  - Multi-select Distrik: checkbox list + search + Pilih Semua + badge preview
  - Multi-select KT: checkbox list + search + Pilih Semua + badge preview
  - Edit: pre-populate via getStaffById() fetch sebelum buka modal
- Detail page: profil + direct reports clickable + tabel distrik + tabel KT
- Semantik kosong = semua: label di form, badge di list & detail
- Delete guard: staff yang masih jadi line manager tidak bisa dihapus
- 14 unit tests: schema validation, email, optional fields, staff code format

Build: OK | Tests: 130/130