### PR TITLE
fix(nav/rbac): sidebar menu search + collapse-all, close RBAC cascade…

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,7 +2,7 @@
 
 > Dokumen kerja untuk memantau delivery Smallholder HUB. Status di dokumen ini disinkronkan terhadap **file dan code yang benar-benar ada di repository**, bukan berdasarkan klaim changelog historis.
 
-**Last updated:** 2026-07-09 (MAP-01 #113: section **Peta Lainnya** (overlay referensi SIGAP KLHK/Kemenhut via proxy tile `api/map-overlay/[key]`) + section **Tambah Data GIS Lain** (user tambah layer WMS/Shapefile/GeoJSON, parse di browser) ditambahkan ke Peta Lahan. Sebelumnya, #99 DASH-01 Dashboard Snapshot selesai: Main Dashboard `/admin/dashboard/main` + peta MapLibre + snapshot module `/admin/tools/snapshot` + `MainDashboardSnapshot` model/migration; test lokal 19 files / 216 tests ✅. Sebelumnya: #107 RPT-01 & #108 RPT-02 ✅; #109 RPT-03 siap dikerjakan. Baru: stream `MAP` + **MAP-01 Map/Peta Lahan (#113) selesai** — peta full-bleed + filter floating + info popup accordion (Detail/Pelatihan lazy-load/Produksi dummy); test 20 files / 227 ✅)
+**Last updated:** 2026-07-09 (MAP-01 #113: section **Peta Lainnya** (overlay referensi SIGAP KLHK/Kemenhut via proxy tile `api/map-overlay/[key]`) + section **Tambah Data GIS Lain** (user tambah layer WMS/Shapefile/GeoJSON, parse di browser) ditambahkan ke Peta Lahan. Sebelumnya, #99 DASH-01 Dashboard Snapshot selesai: Main Dashboard `/admin/dashboard/main` + peta MapLibre + snapshot module `/admin/tools/snapshot` + `MainDashboardSnapshot` model/migration; test lokal 19 files / 216 tests ✅. Sebelumnya: #107 RPT-01 & #108 RPT-02 ✅; #109 RPT-03 siap dikerjakan. Baru: stream `MAP` + **MAP-01 Map/Peta Lahan (#113) selesai** — peta full-bleed + filter floating + info popup accordion (Detail/Pelatihan lazy-load/Produksi dummy); test 20 files / 227 ✅. **Navigation/RBAC hardening (2026-07-09):** sidebar dapat **filter pencarian menu** (Ctrl/⌘K) + tombol **Tutup semua**; `filterMenuTreeByAccess` (menu-utils) menampilkan induk sebagai container tanpa perlu grant induk → menutup **cascade over-grant** (role MANAGEMENT sempat bocor akses Settings→User/Role/Menu Mgmt); MapLibre glyph fix (single-font); +10 test `menu-filter`; test 22 files / 264 ✅)
 
 **Next management review:** 2026-07-14
 
@@ -39,7 +39,7 @@ Gunakan section ini untuk presentasi management setiap dua minggu. Section ini s
 | Report              | 🟠 Partial      | RPT-01 Petani (#107) ✅ & RPT-02 Pelatihan (#108) ✅ selesai (route + `report.ts` + UI + test). **Issue #109 (RPT-03 Produksi) siap dikerjakan.** |
 | Bulk Upload         | ✅ Partial      | Farmer bulk upload ✅, Shapefile bulk upload ✅, Production bulk upload ✅. Region bulk upload belum ada. |
 | Navigation health   | ✅ Fixed        | `/admin/master-data` redirect ke `/admin/master-data/farmers` — **route exists & functional** ✅                                         |
-| Testing             | ✅ Strong       | Vitest: 18 files / 208 tests passed. Coverage: auth/RBAC/menu/user/region/farmer/land-parcel/training/production/bulk-upload/report ✅; need dashboard. |
+| Testing             | ✅ Strong       | Vitest: 22 files / 264 tests passed. Coverage: auth/RBAC/menu/menu-filter/user/region/farmer/land-parcel/training/production/bulk-upload/report ✅; need dashboard. |
 
 ### Progress Snapshot
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -200,6 +200,9 @@ Sistem menu mendukung hierarki sampai **3 level maksimal**:
 - **Override eksplisit** di level lebih dalam meng-override inheritance (revoke atau grant)
 - Contoh: User punya VIEW di "Pelatihan" (level 2) → otomatis VIEW di "Peserta Pelatihan" (level 3), kecuali ada explicit REVOKE
 
+> [!WARNING]
+> **Cascade = risiko over-grant.** Grant pada menu **induk** mewariskan permission ke **semua** anak (termasuk menu sensitif seperti User/Role/Menu Management). Untuk akses **granular**, grant di level **anak**, jangan induk. Sidebar (`filterMenuTreeByAccess` di `menu-utils.ts`) tetap menampilkan induk sebagai **container** selama salah satu anaknya ter-grant — jadi grant per-anak **tidak** memerlukan grant induk. Konsekuensi: jangan mensyaratkan induk ter-grant hanya agar anak tampil. (Audit lintas-role: `scripts/local/audit-cascade.ts`.)
+
 **UI Guidelines:**
 - **Max children:** Level 2 maksimal 5 children (level 3) — hindari clutter, pertimbangkan pagination/search jika > 5
 - **Dynamic route:** Level 3 gunakan dynamic route jika context-specific: `/admin/master-data/training/[id]/participants`
@@ -340,6 +343,7 @@ Untuk upload data geospatial menggunakan Shapefile (`.shp` dalam format ZIP), ik
 
 Untuk fitur yang memerlukan visualisasi dan interaksi dengan data geospasial (koordinat, polygon, area):
 - **Map Display**: Gunakan MapLibre GL JS untuk menampilkan peta interaktif
+- **Fonts/Glyphs**: `text-font` pada symbol layer wajib **font tunggal** yang tersedia di server glyph (`fonts.openmaptiles.org`), mis. `["Open Sans Regular"]`. **Jangan** pakai fontstack gabungan (mis. `["Open Sans Regular", "Noto Sans Regular"]`) — server tidak melayaninya dan malah membalas HTML, sehingga MapLibre gagal parse PBF: `Unable to load glyph range 0, 0-255 / Unimplemented type: 4`.
 - **Polygon Viewer**: 
   - Parse GeoJSON polygon dari database
   - Render polygon sebagai layer di map dengan styling (fill color, stroke)

--- a/docs/ui-ux-flow.md
+++ b/docs/ui-ux-flow.md
@@ -73,6 +73,8 @@
 
 ## Admin Sidebar Menu (Compact View)
 
+> **Perilaku sidebar:** header punya **filter pencarian menu** (input, fokus via Ctrl/⌘K, hapus via Esc/✕) yang memfilter pohon menu secara live + tombol **Tutup semua** (collapse-all). Menu induk otomatis tampil sebagai **container** bila salah satu anaknya ter-grant meski induk tak di-grant (lihat `rule.md` §RBAC Permission Inheritance). Pencarian hanya menampilkan menu sesuai hak akses user.
+
 ```
 📊 Dashboard (✅ DASH-01)
    ├── ✅ Main Dashboard — Snapshot-backed: 10 summary cards (5/baris, incl. Petani L/P) + filter Distrik/KT/Tahun + peta MapLibre (cluster, label nama KT pada titik non-cluster, dark/light/hybrid, search KT, Lihat Semua) + info panel per-KT

--- a/src/app/(admin)/admin/dashboard/dashboard-map.tsx
+++ b/src/app/(admin)/admin/dashboard/dashboard-map.tsx
@@ -13,6 +13,12 @@ import type { KTDetails } from "@/types/dashboard";
 
 const GLYPHS = "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf";
 
+// Single font only: fonts.openmaptiles.org does not serve *combined* fontstacks
+// (e.g. "Open Sans Regular,Noto Sans Regular" returns its HTML landing page,
+// which MapLibre then fails to parse as PBF → "Unable to load glyph range /
+// Unimplemented type: 4"). "Open Sans Regular" is served as a valid glyph PBF.
+const TEXT_FONT = ["Open Sans Regular"];
+
 const MAP_STYLES = {
   light: {
     version: 8 as const,
@@ -154,7 +160,7 @@ export function DashboardMap({ kelompokTaniList, selectedId, onSelect }: Props) 
     filter: ["has", "point_count"] as any,
     layout: {
       "text-field": ["get", "point_count_abbreviated"] as any,
-      "text-font": ["Open Sans Regular", "Noto Sans Regular"],
+      "text-font": TEXT_FONT,
       "text-size": 12,
     },
     paint: { "text-color": "#ffffff" },
@@ -186,7 +192,7 @@ export function DashboardMap({ kelompokTaniList, selectedId, onSelect }: Props) 
     filter: ["!", ["has", "point_count"]] as any,
     layout: {
       "text-field": ["get", "name"] as any,
-      "text-font": ["Open Sans Regular", "Noto Sans Regular"],
+      "text-font": TEXT_FONT,
       "text-size": 11,
       "text-anchor": "top" as const,
       "text-offset": [0, 0.9] as [number, number],

--- a/src/app/(admin)/admin/settings/roles/role-matrix-client.tsx
+++ b/src/app/(admin)/admin/settings/roles/role-matrix-client.tsx
@@ -65,8 +65,8 @@ export function RoleMatrixClient({ permissions, menuItems }: Props) {
         </thead>
         <tbody>
           {parents.map((parent) => (
-            <>
-              <tr key={parent.key} className="bg-muted/30 border-b border-border/50">
+            <React.Fragment key={parent.key}>
+              <tr className="bg-muted/30 border-b border-border/50">
                 <td className="p-2 font-medium">{parent.title}</td>
                 {ROLES.map((role) =>
                   PERMISSIONS.map((perm) => (
@@ -106,7 +106,7 @@ export function RoleMatrixClient({ permissions, menuItems }: Props) {
                   )}
                 </tr>
               ))}
-            </>
+            </React.Fragment>
           ))}
         </tbody>
       </table>

--- a/src/components/layout/admin/app-sidebar-client.tsx
+++ b/src/components/layout/admin/app-sidebar-client.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as React from "react";
+import { usePathname } from "next/navigation";
 import { NavMain } from "@/components/layout/admin/nav-main";
+import { NavSearch } from "@/components/layout/admin/nav-search";
 import { NavUser } from "@/components/layout/admin/nav-user";
 import {
   Sidebar,
@@ -40,6 +42,31 @@ export function AppSidebarClient({ menuItems, user, ...props }: AppSidebarClient
     })),
   }));
 
+  const pathname = usePathname();
+
+  // Open-state for top-level groups; shared so "Tutup semua" can close them all.
+  // Initialised once: open only groups that contain the active route.
+  const [openGroups, setOpenGroups] = React.useState<Record<string, boolean>>(
+    () => {
+      const initial: Record<string, boolean> = {};
+      for (const item of navItems) {
+        if (!item.items || item.items.length === 0) continue;
+        initial[item.title] =
+          !!item.isActive ||
+          item.items.some((subItem) => pathname.startsWith(subItem.url));
+      }
+      return initial;
+    }
+  );
+
+  const collapseAll = () =>
+    setOpenGroups((prev) => {
+      const next: Record<string, boolean> = {};
+      for (const key of Object.keys(prev)) next[key] = false;
+      return next;
+    });
+
+  const [query, setQuery] = React.useState("");
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -58,9 +85,19 @@ export function AppSidebarClient({ menuItems, user, ...props }: AppSidebarClient
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
+        <NavSearch
+          query={query}
+          setQuery={setQuery}
+          onCollapseAll={collapseAll}
+        />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={navItems} />
+        <NavMain
+          items={navItems}
+          openGroups={openGroups}
+          setOpenGroups={setOpenGroups}
+          query={query}
+        />
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={{ name: user.name, email: user.email, avatar: "" }} />

--- a/src/components/layout/admin/app-sidebar.tsx
+++ b/src/components/layout/admin/app-sidebar.tsx
@@ -3,6 +3,7 @@ import { AppSidebarClient } from "@/components/layout/admin/app-sidebar-client";
 import { getMenuItems } from "@/server/actions/menu";
 import { getAccessibleMenuKeys } from "@/lib/rbac";
 import { auth } from "@/lib/auth";
+import { filterMenuTreeByAccess } from "@/lib/menu-utils";
 import type { Sidebar } from "@/components/ui/sidebar";
 
 export async function AppSidebar(
@@ -23,21 +24,12 @@ export async function AppSidebar(
     return <AppSidebarClient menuItems={allMenuItems} user={user} {...props} />;
   }
 
-  // Other roles: filter by permission
-  const accessibleKeys = await getAccessibleMenuKeys(role, session?.user?.id);
- 
-  function filterMenuTree(items: any[]): any[] {
-    return items
-      .filter((item) => accessibleKeys.includes(item.key))
-      .map((item) => ({
-        ...item,
-        children: filterMenuTree(item.children || []),
-      }))
-      .filter((item) => (item.children && item.children.length > 0) || accessibleKeys.includes(item.key));
-  }
- 
-  const filteredMenuItems = filterMenuTree(allMenuItems);
- 
+  // Other roles: filter by permission (Set → O(1) membership per node).
+  const accessibleKeys = new Set(
+    await getAccessibleMenuKeys(role, session?.user?.id)
+  );
+  const filteredMenuItems = filterMenuTreeByAccess(allMenuItems, accessibleKeys);
+
   return <AppSidebarClient menuItems={filteredMenuItems} user={user} {...props} />;
 }
 

--- a/src/components/layout/admin/nav-filter.ts
+++ b/src/components/layout/admin/nav-filter.ts
@@ -1,0 +1,26 @@
+import type { NavItem } from "@/components/layout/admin/nav-types"
+
+/**
+ * Filter the sidebar menu tree by a search query. A node is kept when its own
+ * title matches (then all its children are kept for context) or any descendant
+ * matches. An empty/blank query returns the input unchanged.
+ */
+export function filterNavByQuery(items: NavItem[], query: string): NavItem[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return items
+
+  const walk = (nodes: NavItem[]): NavItem[] => {
+    const out: NavItem[] = []
+    for (const item of nodes) {
+      const selfMatch = item.title.toLowerCase().includes(q)
+      const children = item.items ?? []
+      const filteredChildren = selfMatch ? children : walk(children)
+      if (selfMatch || filteredChildren.length > 0) {
+        out.push({ ...item, items: filteredChildren })
+      }
+    }
+    return out
+  }
+
+  return walk(items)
+}

--- a/src/components/layout/admin/nav-main.tsx
+++ b/src/components/layout/admin/nav-main.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
@@ -10,7 +11,6 @@ import {
 } from "@/components/ui/collapsible"
 import {
   SidebarGroup,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -20,34 +20,39 @@ import {
 } from "@/components/ui/sidebar"
 import { ChevronRightIcon } from "lucide-react"
 import { ICON_MAP } from "@/lib/icon-map"
+import type { NavItem } from "@/components/layout/admin/nav-types"
+import { filterNavByQuery } from "@/components/layout/admin/nav-filter"
 
 export function NavMain({
   items,
+  openGroups,
+  setOpenGroups,
+  query,
 }: {
-  items: {
-    title: string
-    url: string
-    icon?: string
-    isActive?: boolean
-    items?: {
-      title: string
-      url: string
-      icon?: string
-      items?: {
-        title: string
-        url: string
-        icon?: string
-      }[]
-    }[]
-  }[]
+  items: NavItem[]
+  openGroups: Record<string, boolean>
+  setOpenGroups: React.Dispatch<React.SetStateAction<Record<string, boolean>>>
+  query: string
 }) {
   const pathname = usePathname()
- 
+
+  const filtering = query.trim().length > 0
+  const displayItems = filterNavByQuery(items, query)
+
+  if (filtering && displayItems.length === 0) {
+    return (
+      <SidebarGroup>
+        <p className="px-2 py-4 text-sm text-muted-foreground">
+          Menu tidak ditemukan.
+        </p>
+      </SidebarGroup>
+    )
+  }
+
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Menu Admin</SidebarGroupLabel>
       <SidebarMenu>
-        {items.map((item) => {
+        {displayItems.map((item) => {
           const RootIcon = item.icon ? ICON_MAP[item.icon] : null
  
           // If no sub-items, render a simple link
@@ -66,12 +71,13 @@ export function NavMain({
             )
           }
  
-          const isCollapsibleOpen = item.isActive || item.items?.some((subItem) => pathname.startsWith(subItem.url))
- 
           return (
             <Collapsible
               key={item.title}
-              defaultOpen={isCollapsibleOpen}
+              open={filtering || (openGroups[item.title] ?? false)}
+              onOpenChange={(open) =>
+                setOpenGroups((prev) => ({ ...prev, [item.title]: open }))
+              }
               className="group/collapsible"
               render={<SidebarMenuItem />}
             >
@@ -107,8 +113,8 @@ export function NavMain({
 
                     return (
                       <Collapsible
-                        key={subItem.title}
-                        defaultOpen={isSubCollapsibleOpen}
+                        key={subItem.title + (filtering ? "-f" : "")}
+                        defaultOpen={filtering || isSubCollapsibleOpen}
                         className="group/subcollapsible w-full"
                         render={<SidebarMenuSubItem />}
                       >

--- a/src/components/layout/admin/nav-search.tsx
+++ b/src/components/layout/admin/nav-search.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  SidebarMenu,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { SearchIcon, XIcon, ChevronsDownUpIcon } from "lucide-react"
+
+export function NavSearch({
+  query,
+  setQuery,
+  onCollapseAll,
+}: {
+  query: string
+  setQuery: (value: string) => void
+  onCollapseAll: () => void
+}) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  // Ctrl/⌘+K focuses the filter; Esc clears it while focused.
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [])
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem className="flex items-center gap-1 group-data-[collapsible=icon]:hidden">
+        <div className="relative flex-1">
+          <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && query) {
+                e.preventDefault()
+                setQuery("")
+              }
+            }}
+            placeholder="Cari menu…"
+            aria-label="Cari menu"
+            className="h-8 w-full rounded-md border border-input/60 bg-input/30 pr-7 pl-7 text-sm outline-hidden placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-sidebar-ring/40"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery("")
+                inputRef.current?.focus()
+              }}
+              title="Hapus pencarian"
+              aria-label="Hapus pencarian"
+              className="absolute top-1/2 right-1.5 flex size-5 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onCollapseAll}
+          title="Tutup semua menu"
+          aria-label="Tutup semua menu"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+        >
+          <ChevronsDownUpIcon className="size-4" />
+        </button>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/src/components/layout/admin/nav-types.ts
+++ b/src/components/layout/admin/nav-types.ts
@@ -1,0 +1,16 @@
+export type NavItem = {
+  title: string
+  url: string
+  icon?: string
+  isActive?: boolean
+  items?: {
+    title: string
+    url: string
+    icon?: string
+    items?: {
+      title: string
+      url: string
+      icon?: string
+    }[]
+  }[]
+}

--- a/src/lib/menu-utils.ts
+++ b/src/lib/menu-utils.ts
@@ -34,6 +34,31 @@ export function buildMenuTree(
 }
 
 /**
+ * Filter a menu tree down to what a user may access. A node is kept if its own
+ * key is accessible OR it still has an accessible descendant — so a parent can
+ * render purely as a container when only a specific child is granted, without
+ * granting the parent (which would cascade VIEW to every sibling).
+ *
+ * `accessibleKeys` is a Set for O(1) membership checks (the tree is walked once
+ * per node, so a linear `Array.includes` would be O(n·k)).
+ */
+export function filterMenuTreeByAccess(
+  items: MenuItem[],
+  accessibleKeys: Set<string>
+): MenuItem[] {
+  return items
+    .map((item) => ({
+      ...item,
+      children: filterMenuTreeByAccess(item.children || [], accessibleKeys),
+    }))
+    .filter(
+      (item) =>
+        accessibleKeys.has(item.key) ||
+        (item.children != null && item.children.length > 0)
+    );
+}
+
+/**
  * Validates if adding/updating a menu item under a parentKey does not exceed maxDepth (3).
  * If the menu tree would have a depth > 3, it should return false.
  * Items is the list of all existing menu items.

--- a/src/test/menu-filter.test.ts
+++ b/src/test/menu-filter.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { filterMenuTreeByAccess, type MenuItem } from "@/lib/menu-utils";
+import { filterNavByQuery } from "@/components/layout/admin/nav-filter";
+import type { NavItem } from "@/components/layout/admin/nav-types";
+
+// Shared fixture: Settings (parent) with 4 children.
+function settingsTree(): MenuItem[] {
+  const child = (key: string, title: string): MenuItem => ({
+    key,
+    parentKey: "settings",
+    title,
+    url: `/admin/settings/${key}`,
+    icon: null,
+    children: [],
+  });
+  return [
+    {
+      key: "settings",
+      parentKey: null,
+      title: "Settings",
+      url: "#",
+      icon: null,
+      children: [
+        child("settings-users", "User Management"),
+        child("settings-menu", "Menu Management"),
+        child("settings-roles", "Role & Permission"),
+        child("settings-regions", "Regions"),
+      ],
+    },
+  ];
+}
+
+describe("filterMenuTreeByAccess (RBAC menu visibility)", () => {
+  it("shows the parent as a container when only a child is granted", () => {
+    // Facilitator granted ONLY the Regions child — NOT the Settings parent.
+    const keys = new Set(["settings-regions"]);
+    const result = filterMenuTreeByAccess(settingsTree(), keys);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("settings");
+    // Only Regions survives; sibling admin menus are gone.
+    expect(result[0].children?.map((c) => c.key)).toEqual(["settings-regions"]);
+  });
+
+  it("does NOT leak sibling menus when a child is granted", () => {
+    const keys = new Set(["settings-regions"]);
+    const result = filterMenuTreeByAccess(settingsTree(), keys);
+    const childKeys = result[0].children?.map((c) => c.key) ?? [];
+
+    expect(childKeys).not.toContain("settings-users");
+    expect(childKeys).not.toContain("settings-menu");
+    expect(childKeys).not.toContain("settings-roles");
+  });
+
+  it("keeps all granted children (e.g. cascade-style full grant)", () => {
+    const keys = new Set([
+      "settings",
+      "settings-users",
+      "settings-menu",
+      "settings-roles",
+      "settings-regions",
+    ]);
+    const result = filterMenuTreeByAccess(settingsTree(), keys);
+    expect(result[0].children).toHaveLength(4);
+  });
+
+  it("drops a parent entirely when no descendant is accessible", () => {
+    const keys = new Set(["some-other-menu"]);
+    const result = filterMenuTreeByAccess(settingsTree(), keys);
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps a leaf-only accessible top-level menu", () => {
+    const items: MenuItem[] = [
+      { key: "dashboard", parentKey: null, title: "Dashboard", url: "/admin/dashboard", icon: null, children: [] },
+    ];
+    expect(filterMenuTreeByAccess(items, new Set(["dashboard"]))).toHaveLength(1);
+    expect(filterMenuTreeByAccess(items, new Set())).toHaveLength(0);
+  });
+});
+
+describe("filterNavByQuery (sidebar search)", () => {
+  const nav: NavItem[] = [
+    {
+      title: "Settings",
+      url: "#",
+      items: [
+        { title: "User Management", url: "/admin/settings/users" },
+        { title: "Regions", url: "/admin/settings/regions" },
+      ],
+    },
+    {
+      title: "Master Data",
+      url: "#",
+      items: [{ title: "Petani", url: "/admin/master-data/farmers" }],
+    },
+  ];
+
+  it("returns the input unchanged for a blank query", () => {
+    expect(filterNavByQuery(nav, "")).toBe(nav);
+    expect(filterNavByQuery(nav, "   ")).toBe(nav);
+  });
+
+  it("keeps only branches whose descendant matches", () => {
+    const result = filterNavByQuery(nav, "user");
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Settings");
+    expect(result[0].items?.map((i) => i.title)).toEqual(["User Management"]);
+  });
+
+  it("is case-insensitive and matches on substring", () => {
+    const result = filterNavByQuery(nav, "PETAN");
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Master Data");
+  });
+
+  it("keeps all children when the parent title itself matches", () => {
+    const result = filterNavByQuery(nav, "settings");
+    expect(result[0].items).toHaveLength(2);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(filterNavByQuery(nav, "zzz")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
… leak, map glyph (#120)

- Sidebar: inline menu search (Ctrl/⌘K focus, Esc/✕ clear) + collapse-all; controlled open-state lifted to app-sidebar-client
- RBAC: filterMenuTreeByAccess (menu-utils) shows a parent as container when a child is granted (Set O(1) lookup) — enables granular child grants without the parent grant that cascades VIEW/CRUD to every sibling
- Map: MapLibre text-font single-font fix; combined fontstack returns HTML from fonts.openmaptiles.org → "Unable to load glyph range / Unimplemented type: 4"
- UI: React key fix in role matrix (<> → React.Fragment key)
- Tests: +10 menu-filter unit tests (264 total); build + vitest green
- Docs: rule.md (RBAC inheritance + MapLibre glyphs), ui-ux-flow.md, progress.md